### PR TITLE
feat: mark external links automatically

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,18 +5,29 @@ import autoprefixer from 'autoprefixer';
 import sitemap from '@astrojs/sitemap';
 import backlinks from './astro.backlinks.ts';
 import remarkWikiLinks from './remark-wikilinks.ts';
+import rehypeExternalLinks from './rehype-external-links.ts';
+
+// The deployed origin, declared once. `rehype-external-links.ts` decides what
+// counts as external by comparing hosts against it, so the site's own host is
+// configuration here rather than a constant baked into the engine.
+const site = 'https://devonmeadows.com';
 
 // https://astro.build/config
 export default defineConfig({
-	site: 'https://devonmeadows.com',
+	site,
 	// Astro 7 renders markdown with Sätteri and no longer installs
 	// `@astrojs/markdown-remark`. `remark-wikilinks.ts` is the mechanism this
 	// whole project exists for, so the unified pipeline is reinstalled and kept
 	// rather than ported: a Sätteri port is a rewrite of the product's core, not
 	// a step in an engine upgrade, and it gets its own ticket.
+	//
+	// The plugins go to `unified()` rather than to `markdown.remarkPlugins` and
+	// `markdown.rehypePlugins`, which Astro 7 deprecates and forwards here with
+	// a warning.
 	markdown: {
 		processor: unified({
 			remarkPlugins: [remarkWikiLinks],
+			rehypePlugins: [[rehypeExternalLinks, { site }]],
 		}),
 	},
 	// Tailwind runs as a plain PostCSS plugin rather than through

--- a/rehype-external-links.ts
+++ b/rehype-external-links.ts
@@ -1,0 +1,54 @@
+/**
+ * Rehype plugin to open every external link in a new tab.
+ *
+ * The design system marks `a[target="_blank"]` with an arrow, so setting the
+ * attribute here is what makes that marker automatic for plain markdown links.
+ */
+
+import { visit } from 'unist-util-visit';
+import type { Root } from 'hast';
+
+export interface ExternalLinksOptions {
+	/** The site's own origin, exactly as `astro.config.mjs` declares `site`. */
+	site?: string | URL;
+}
+
+/**
+ * Rehype plugin function
+ */
+export default function rehypeExternalLinks({ site }: ExternalLinksOptions = {}) {
+	// A link is internal because it points at the site's own host, and the
+	// engine has no host of its own: it comes from the Astro `site` config.
+	// Without one, nothing can be recognised as internal by hostname — only
+	// relative links stay untouched.
+	const siteHost = site ? new URL(site).hostname : null;
+
+	return function transformer(tree: Root) {
+		visit(tree, 'element', (node) => {
+			if (node.tagName !== 'a') return;
+
+			// A link that already declares `target` was written by hand — raw
+			// HTML in a note, or a component — and owns its own `rel`.
+			// Overwriting it would drop attributes its author chose.
+			if (node.properties?.target !== undefined) return;
+
+			const href = node.properties?.href;
+			if (typeof href !== 'string') return;
+
+			// Wikilinks and internal links are relative, so they have no
+			// protocol, never match here, and are left alone.
+			if (!href.startsWith('http://') && !href.startsWith('https://')) return;
+
+			let hostname;
+			try {
+				hostname = new URL(href).hostname;
+			} catch {
+				return;
+			}
+			if (hostname === siteHost) return;
+
+			node.properties.target = '_blank';
+			node.properties.rel = ['noopener', 'noreferrer'];
+		});
+	};
+}

--- a/tests/external-links.test.mjs
+++ b/tests/external-links.test.mjs
@@ -1,0 +1,61 @@
+/**
+ * Tests for the external-link rehype pass.
+ *
+ * The plugin is what makes the design system's `a[target="_blank"]` marker
+ * automatic, so what matters is exactly which links it claims: the attribute
+ * is a visible arrow on the page, and a false positive marks an internal link
+ * as leaving the site. These run the transformer over hand-built hast rather
+ * than through Astro — the unit under test is the decision, not the pipeline.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import rehypeExternalLinks from '../rehype-external-links.ts';
+
+const SITE = 'https://devonmeadows.com';
+
+/** One `<a>` element node, the shape rehype hands the plugin. */
+function anchor(href, properties = {}) {
+	return {
+		type: 'element',
+		tagName: 'a',
+		properties: { href, ...properties },
+		children: [{ type: 'text', value: 'link' }],
+	};
+}
+
+/** Run the plugin over a tree of the given anchors, returning them mutated. */
+function transform(...anchors) {
+	rehypeExternalLinks({ site: SITE })({ type: 'root', children: anchors });
+	return anchors;
+}
+
+test('an external link opens in a new tab and is told not to leak the referrer', () => {
+	const [node] = transform(anchor('https://example.com/post'));
+
+	assert.equal(node.properties.target, '_blank');
+	assert.deepEqual(node.properties.rel, ['noopener', 'noreferrer']);
+});
+
+test("an absolute link to the site's own host is internal", () => {
+	const [node] = transform(anchor(`${SITE}/notes/atomic-notes/`));
+
+	assert.equal(node.properties.target, undefined);
+	assert.equal(node.properties.rel, undefined);
+});
+
+test('a relative link — every wikilink is one — is left alone', () => {
+	const [node] = transform(anchor('/notes/atomic-notes/'));
+
+	assert.equal(node.properties.target, undefined);
+	assert.equal(node.properties.rel, undefined);
+});
+
+test('a link that already carries target keeps the rel its author wrote', () => {
+	const [node] = transform(
+		anchor('https://example.com/post', { target: '_blank', rel: ['me'] })
+	);
+
+	assert.equal(node.properties.target, '_blank');
+	assert.deepEqual(node.properties.rel, ['me']);
+});


### PR DESCRIPTION
Ports the rule devon-wiki shipped in dmthepm/devon-wiki#5 into the engine: every `http(s)` markdown link gets `target="_blank"` and `rel="noopener noreferrer"` from a rehype pass, so the design system's `↗` marker is automatic. Map record: #2, comment of 2026-09-03 (automatic-by-default is a product rule). The harness deletes its copy under #7.

- `rehype-external-links.ts`: own file beside `remark-wikilinks.ts`. Internal is decided by exact hostname match against the Astro `site` config, never a hardcoded domain. Links that already declare `target` are left untouched, so hand-written HTML keeps its own `rel`.
- Wired through `unified({ rehypePlugins })` inside `markdown.processor`, not the top-level `markdown.rehypePlugins` key Astro 7 deprecates.
- `tests/external-links.test.mjs`: external gets both attributes; same-host absolute does not; relative does not; pre-set `target` keeps its `rel`.

Receipt at `ab6706b`: 79 tests pass (was 75), `pnpm build` green with `41 total backlinks across 11 entries`, `public/backlinks.json` byte-identical, zero doubled attributes in `dist/`.

Open: subdomains of the site host count as external (exact match). Flip to suffix match if `www.` or any subdomain should be internal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1XXFXAsDP1ftHkaRbgwwz