### PR TITLE
feat(#31): serve every note as markdown at its own URL

### DIFF
--- a/astro.backlinks.ts
+++ b/astro.backlinks.ts
@@ -1,15 +1,16 @@
 /**
- * Astro integration for building backlinks and graph data at build time.
+ * Astro integration for building backlinks and graph data at build time, and
+ * for writing each entry's source markdown beside its rendered page.
  *
- * Thin by design: it owns *when* the graph is built and *where* the artifact is
- * written, and nothing else. Which content exists, how links resolve, how stars
- * are ranked and what counts as a finding are all decided by the graph core in
- * `src/lib/graph.ts`, so the `commune` CLI produces the same graph without an
- * Astro process anywhere in sight.
+ * Thin by design: it owns *when* the graph is built and *where* the artifacts
+ * are written, and nothing else. Which content exists, how links resolve, how
+ * stars are ranked and what counts as a finding are all decided by the graph
+ * core in `src/lib/graph.ts`, so the `commune` CLI produces the same graph
+ * without an Astro process anywhere in sight.
  */
 
 import type { AstroIntegration } from 'astro';
-import { writeFile, mkdir } from 'node:fs/promises';
+import { copyFile, writeFile, mkdir } from 'node:fs/promises';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import {
@@ -17,12 +18,17 @@ import {
 	formatDiagnostic,
 	loadContentEntries,
 	toBacklinksJson,
+	toMarkdownPath,
+	type ContentEntry,
 	type Graph,
 	type NoteMetadata,
 } from './src/lib/graph.ts';
 
-async function buildBacklinksGraph(logger: Pick<Console, 'info' | 'warn'>): Promise<Graph> {
-	const graph = buildGraph(await loadContentEntries());
+function buildBacklinksGraph(
+	entries: ContentEntry[],
+	logger: Pick<Console, 'info' | 'warn'>
+): Graph {
+	const graph = buildGraph(entries);
 
 	logger.info(`📝 Found ${Object.keys(graph.nodes).length} public content entries`);
 
@@ -43,6 +49,25 @@ async function writeBacklinksFile(filePath: string, graph: Record<string, NoteMe
 	await writeFile(filePath, JSON.stringify(graph, null, 2) + '\n');
 }
 
+/**
+ * Copy every entry's source file next to its rendered page, at `<url>.md`.
+ *
+ * `copyFile` rather than a re-serialization on purpose: the promise of the `.md`
+ * URL is that it returns *the file*, frontmatter and `[[wikilinks]]` untouched,
+ * so anything that reformats on the way through would break it. The graph
+ * already decided which entries exist and where each one lives; this only moves
+ * bytes.
+ */
+async function writeMarkdownFiles(entries: ContentEntry[], outDir: string): Promise<number> {
+	for (const entry of entries) {
+		const destination = path.join(outDir, toMarkdownPath(entry.urlPath));
+		await mkdir(path.dirname(destination), { recursive: true });
+		await copyFile(entry.file, destination);
+	}
+
+	return entries.length;
+}
+
 function summarize(graph: Graph): string {
 	return `📊 ${graph.totalBacklinks} total backlinks across ${Object.keys(graph.nodes).length} entries`;
 }
@@ -58,7 +83,7 @@ export default function backlinksIntegration(): AstroIntegration {
 				logger.info('🔗 Building public backlinks index...');
 
 				try {
-					const graph = await buildBacklinksGraph(logger);
+					const graph = buildBacklinksGraph(await loadContentEntries(), logger);
 					await writeBacklinksFile(path.join('public', 'backlinks.json'), toBacklinksJson(graph));
 					logger.info(`✅ Backlinks index written to public/backlinks.json`);
 					logger.info(summarize(graph));
@@ -72,7 +97,8 @@ export default function backlinksIntegration(): AstroIntegration {
 				logger.info('🔗 Building backlinks index...');
 
 				try {
-					const graph = await buildBacklinksGraph(logger);
+					const entries = await loadContentEntries();
+					const graph = buildBacklinksGraph(entries, logger);
 					const json = toBacklinksJson(graph);
 
 					// `dir` is a URL, and `dir.pathname` percent-encodes: a project
@@ -84,7 +110,10 @@ export default function backlinksIntegration(): AstroIntegration {
 					// Use relative path from cwd to handle different build contexts
 					await writeBacklinksFile(path.join('public', 'backlinks.json'), json);
 
+					const written = await writeMarkdownFiles(entries, fileURLToPath(dir));
+
 					logger.info(`✅ Backlinks index written to /backlinks.json (dist + public)`);
+					logger.info(`📄 ${written} source files written as .md alongside their pages`);
 					logger.info(summarize(graph));
 
 				} catch (error) {

--- a/src/components/MarkdownLink.astro
+++ b/src/components/MarkdownLink.astro
@@ -1,0 +1,36 @@
+---
+/**
+ * "view as markdown" — the source-file affordance on every rendered entry.
+ *
+ * Deliberately one line of text: the real interface is the URL convention
+ * (append `.md` to any page), and this link is only the thing that teaches a
+ * reader the convention exists. A card or an icon would sell it as a feature.
+ */
+interface Props {
+	href: string;
+}
+
+const { href } = Astro.props;
+---
+<p class="markdown-link"><a href={href}>view as markdown</a></p>
+
+<style>
+  .markdown-link {
+    margin: 2.5rem 0 0;
+    font-size: 0.9rem;
+    color: var(--c-text-muted);
+  }
+
+  .markdown-link a {
+    color: var(--c-text-muted);
+    text-decoration: none;
+    border-bottom: 1px solid var(--c-border);
+    padding-bottom: 1px;
+    transition: all 0.15s ease;
+  }
+
+  .markdown-link a:hover {
+    color: var(--c-accent);
+    border-bottom-color: var(--c-accent);
+  }
+</style>

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -107,6 +107,30 @@ export function toUrlPath(
 	return { slug, urlPath: `/${collection}/${slug}/` };
 }
 
+/**
+ * Convert a canonical URL path to the path of its markdown twin.
+ *
+ * Every note is served twice at one URL: `/notes/cake/` renders the page,
+ * `/notes/cake.md` returns the source file. The mapping is pure string work —
+ * drop the trailing slash, append `.md` — so the build writer, the page
+ * templates and any future route can all agree on it without touching disk.
+ * The home page (`/`) has no name to hang the suffix on, so it gets `index.md`.
+ *
+ * The result is always relative, with no leading slash: callers join it onto
+ * `dist/` or prefix it with `/` for a URL. Traversal segments are rejected
+ * rather than normalized, since a `url` frontmatter is author-controlled and a
+ * `..` in it would otherwise let a build write outside its output directory.
+ */
+export function toMarkdownPath(urlPath: string): string {
+	const segments = urlPath.split('/').filter((segment) => segment.length > 0);
+
+	if (segments.some((segment) => segment === '.' || segment === '..')) {
+		throw new Error(`Cannot map a URL path with a relative segment: ${urlPath}`);
+	}
+
+	return segments.length === 0 ? 'index.md' : `${segments.join('/')}.md`;
+}
+
 /** Coerce a frontmatter date to `yyyy-mm-dd`, so build output has no timestamp drift. */
 export function normalizeDate(value: unknown): string | undefined {
 	if (!value) return undefined;

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -108,18 +108,20 @@ export function toUrlPath(
 }
 
 /**
- * Convert a canonical URL path to the path of its markdown twin.
+ * Convert a canonical URL path to the *file* path of its markdown twin.
  *
  * Every note is served twice at one URL: `/notes/cake/` renders the page,
  * `/notes/cake.md` returns the source file. The mapping is pure string work —
- * drop the trailing slash, append `.md` — so the build writer, the page
- * templates and any future route can all agree on it without touching disk.
- * The home page (`/`) has no name to hang the suffix on, so it gets `index.md`.
+ * drop the trailing slash, append `.md` — and it lives here rather than in the
+ * build writer so the page templates cannot drift from the files that writer
+ * actually emits. The home page (`/`) has no name to hang the suffix on, so it
+ * gets `index.md`.
  *
- * The result is always relative, with no leading slash: callers join it onto
- * `dist/` or prefix it with `/` for a URL. Traversal segments are rejected
- * rather than normalized, since a `url` frontmatter is author-controlled and a
- * `..` in it would otherwise let a build write outside its output directory.
+ * The result is relative, with no leading slash: the caller joins it onto its
+ * output directory. For the URL a rendered page should link to, use
+ * `toMarkdownHref`. Traversal segments are rejected rather than normalized,
+ * since a `url` frontmatter is author-controlled and a `..` in it would
+ * otherwise let a build write outside its output directory.
  */
 export function toMarkdownPath(urlPath: string): string {
 	const segments = urlPath.split('/').filter((segment) => segment.length > 0);
@@ -129,6 +131,17 @@ export function toMarkdownPath(urlPath: string): string {
 	}
 
 	return segments.length === 0 ? 'index.md' : `${segments.join('/')}.md`;
+}
+
+/**
+ * The site-absolute URL of an entry's markdown twin — what a rendered page links to.
+ *
+ * Derived from `toMarkdownPath` rather than computed alongside it, so a page's
+ * "view as markdown" link and the file the build writes can only ever be the
+ * same string with a leading slash.
+ */
+export function toMarkdownHref(urlPath: string): string {
+	return `/${toMarkdownPath(urlPath)}`;
 }
 
 /** Coerce a frontmatter date to `yyyy-mm-dd`, so build output has no timestamp drift. */

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -16,6 +16,7 @@ import Header from '../components/Header.astro';
 import SearchModal from '../components/SearchModal.astro';
 import Footer from '../components/Footer.astro';
 import MarkdownLink from '../components/MarkdownLink.astro';
+import { toMarkdownHref } from '../lib/graph.ts';
 import PlausibleScript from '../components/PlausibleScript.astro';
 import StarredLinksScript from '../components/StarredLinksScript.astro';
 import '../styles/design-system.css';
@@ -65,7 +66,7 @@ const { data } = entry;
       <Content />
     </article>
 
-    <MarkdownLink href={`${data.url.replace(/\/$/, '')}.md`} />
+    <MarkdownLink href={toMarkdownHref(data.url)} />
 
     <Footer />
   </main>

--- a/src/pages/[...page].astro
+++ b/src/pages/[...page].astro
@@ -15,6 +15,7 @@ import type { CollectionEntry } from 'astro:content';
 import Header from '../components/Header.astro';
 import SearchModal from '../components/SearchModal.astro';
 import Footer from '../components/Footer.astro';
+import MarkdownLink from '../components/MarkdownLink.astro';
 import PlausibleScript from '../components/PlausibleScript.astro';
 import StarredLinksScript from '../components/StarredLinksScript.astro';
 import '../styles/design-system.css';
@@ -63,6 +64,8 @@ const { data } = entry;
       <h1>{data.title}</h1>
       <Content />
     </article>
+
+    <MarkdownLink href={`${data.url.replace(/\/$/, '')}.md`} />
 
     <Footer />
   </main>

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -10,6 +10,7 @@ import HeaderStarScript from '../../components/HeaderStarScript.astro';
 import HomeFooterCards from '../../components/HomeFooterCards.astro';
 import Footer from '../../components/Footer.astro';
 import MarkdownLink from '../../components/MarkdownLink.astro';
+import { toMarkdownHref } from '../../lib/graph.ts';
 import PlausibleScript from '../../components/PlausibleScript.astro';
 import '../../styles/design-system.css';
 import '../../styles/notes.css';
@@ -169,7 +170,7 @@ function getRelativeDate(dateString: string): string {
 
                             <Content />
                         </article>
-                        <MarkdownLink href={`/notes/${slug}.md`} />
+                        <MarkdownLink href={toMarkdownHref(`/notes/${slug}/`)} />
                         <Backlinks slug={`/notes/${slug}/`} title={title} />
                         <HomeFooterCards slug={`/notes/${slug}/`} backlinks={backlinksData} />
                         <Footer />

--- a/src/pages/notes/[...slug].astro
+++ b/src/pages/notes/[...slug].astro
@@ -9,6 +9,7 @@ import StarredLinksScript from '../../components/StarredLinksScript.astro';
 import HeaderStarScript from '../../components/HeaderStarScript.astro';
 import HomeFooterCards from '../../components/HomeFooterCards.astro';
 import Footer from '../../components/Footer.astro';
+import MarkdownLink from '../../components/MarkdownLink.astro';
 import PlausibleScript from '../../components/PlausibleScript.astro';
 import '../../styles/design-system.css';
 import '../../styles/notes.css';
@@ -168,6 +169,7 @@ function getRelativeDate(dateString: string): string {
 
                             <Content />
                         </article>
+                        <MarkdownLink href={`/notes/${slug}.md`} />
                         <Backlinks slug={`/notes/${slug}/`} title={title} />
                         <HomeFooterCards slug={`/notes/${slug}/`} backlinks={backlinksData} />
                         <Footer />

--- a/src/pages/research/[...slug].astro
+++ b/src/pages/research/[...slug].astro
@@ -5,6 +5,7 @@ import Header from '../../components/Header.astro';
 import SearchModal from '../../components/SearchModal.astro';
 import Footer from '../../components/Footer.astro';
 import MarkdownLink from '../../components/MarkdownLink.astro';
+import { toMarkdownHref } from '../../lib/graph.ts';
 import PlausibleScript from '../../components/PlausibleScript.astro';
 import StarredLinksScript from '../../components/StarredLinksScript.astro';
 import '../../styles/design-system.css';
@@ -125,7 +126,7 @@ const formattedWordCount = data.wordCount.toLocaleString();
       <Content />
     </article>
 
-    <MarkdownLink href={`/research/${entry.id}.md`} />
+    <MarkdownLink href={toMarkdownHref(`/research/${entry.id}/`)} />
 
     <!-- Research info box (will be moved via JS to appear after h1) -->
     <div class="research-info-box" id="research-info-box">

--- a/src/pages/research/[...slug].astro
+++ b/src/pages/research/[...slug].astro
@@ -4,6 +4,7 @@ import type { CollectionEntry } from 'astro:content';
 import Header from '../../components/Header.astro';
 import SearchModal from '../../components/SearchModal.astro';
 import Footer from '../../components/Footer.astro';
+import MarkdownLink from '../../components/MarkdownLink.astro';
 import PlausibleScript from '../../components/PlausibleScript.astro';
 import StarredLinksScript from '../../components/StarredLinksScript.astro';
 import '../../styles/design-system.css';
@@ -123,6 +124,8 @@ const formattedWordCount = data.wordCount.toLocaleString();
     <article class="prose research-content" style="max-width: none;">
       <Content />
     </article>
+
+    <MarkdownLink href={`/research/${entry.id}.md`} />
 
     <!-- Research info box (will be moved via JS to appear after h1) -->
     <div class="research-info-box" id="research-info-box">

--- a/tests/markdown-urls.test.mjs
+++ b/tests/markdown-urls.test.mjs
@@ -6,7 +6,9 @@
  * home page and a pinned `slug` can be exercised at all, since the engine's own
  * content has neither. The build half is the promise itself: the file served at
  * `/notes/atomic-notes.md` is byte-for-byte the file an author edits, so it is
- * checked by comparing bytes rather than parsed frontmatter.
+ * checked by comparing bytes rather than parsed frontmatter — and the rendered
+ * page at that URL actually links to it, which is the only assertion that
+ * catches a template computing the suffix its own way.
  *
  * `dist/` is gitignored, so unlike `public/backlinks.json` there is no committed
  * artifact to read and the build has to be spawned here. It runs once, in a
@@ -20,11 +22,14 @@ import { readFile } from 'node:fs/promises';
 import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
-import { loadContentEntries, toMarkdownPath, toUrlPath } from '../src/lib/graph.ts';
+import { loadContentEntries, toMarkdownHref, toMarkdownPath, toUrlPath } from '../src/lib/graph.ts';
 import { run } from './helpers.mjs';
 
 const ROOT = fileURLToPath(new URL('../', import.meta.url));
 const DIST = path.join(ROOT, 'dist');
+
+/** Quote a literal for use inside a RegExp — `.` in a path must not match anything. */
+const escape = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 
 test('a note URL becomes a sibling .md file', () => {
 	assert.equal(toMarkdownPath('/notes/atomic-notes/'), 'notes/atomic-notes.md');
@@ -33,6 +38,12 @@ test('a note URL becomes a sibling .md file', () => {
 
 test('the home page has no name to suffix, so it becomes index.md', () => {
 	assert.equal(toMarkdownPath('/'), 'index.md');
+});
+
+test('the href a page links to is the file path with a leading slash', () => {
+	assert.equal(toMarkdownHref('/notes/atomic-notes/'), '/notes/atomic-notes.md');
+	assert.equal(toMarkdownHref('/about-this-wiki/'), '/about-this-wiki.md');
+	assert.equal(toMarkdownHref('/'), '/index.md');
 });
 
 test('a standalone page lands at the route it declares', () => {
@@ -76,6 +87,22 @@ describe('the built site', () => {
 		const source = await readFile(path.join(ROOT, 'src/content/notes/Atomic Notes.md'));
 
 		assert.deepEqual(built, source);
+	});
+
+	test('links every rendered page to its own markdown twin', async () => {
+		const entries = await loadContentEntries();
+
+		for (const entry of entries) {
+			// Directory build format: `/notes/x/` renders to `notes/x/index.html`.
+			const page = path.join(DIST, entry.urlPath, 'index.html');
+			const html = await readFile(page, 'utf8');
+
+			assert.match(
+				html,
+				new RegExp(`href="${escape(toMarkdownHref(entry.urlPath))}"`),
+				`${entry.urlPath} does not link to its .md`
+			);
+		}
 	});
 
 	test('serves every entry the graph sees as markdown too', async () => {

--- a/tests/markdown-urls.test.mjs
+++ b/tests/markdown-urls.test.mjs
@@ -1,0 +1,93 @@
+/**
+ * Tests for the markdown twin every entry gets at `<url>.md`.
+ *
+ * Two halves, and they check different things. The unit half pins the pure
+ * mapping from a canonical URL to a dist path — cheap, and the only place the
+ * home page and a pinned `slug` can be exercised at all, since the engine's own
+ * content has neither. The build half is the promise itself: the file served at
+ * `/notes/atomic-notes.md` is byte-for-byte the file an author edits, so it is
+ * checked by comparing bytes rather than parsed frontmatter.
+ *
+ * `dist/` is gitignored, so unlike `public/backlinks.json` there is no committed
+ * artifact to read and the build has to be spawned here. It runs once, in a
+ * `before` hook, straight from astro's own bin — `pnpm build` would also run the
+ * search-index gate, which this file has no business asserting on.
+ */
+
+import { test, before, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+import { loadContentEntries, toMarkdownPath, toUrlPath } from '../src/lib/graph.ts';
+import { run } from './helpers.mjs';
+
+const ROOT = fileURLToPath(new URL('../', import.meta.url));
+const DIST = path.join(ROOT, 'dist');
+
+test('a note URL becomes a sibling .md file', () => {
+	assert.equal(toMarkdownPath('/notes/atomic-notes/'), 'notes/atomic-notes.md');
+	assert.equal(toMarkdownPath('/research/why-wikilinks/'), 'research/why-wikilinks.md');
+});
+
+test('the home page has no name to suffix, so it becomes index.md', () => {
+	assert.equal(toMarkdownPath('/'), 'index.md');
+});
+
+test('a standalone page lands at the route it declares', () => {
+	const { urlPath } = toUrlPath('src/content/pages/About this wiki.md', 'pages', {
+		url: '/about-this-wiki/',
+	});
+
+	assert.equal(toMarkdownPath(urlPath), 'about-this-wiki.md');
+});
+
+test('a pinned slug moves the .md file with the page', () => {
+	const { urlPath } = toUrlPath('src/content/notes/Renamed Later.md', 'notes', {
+		slug: 'original-name',
+	});
+
+	assert.equal(urlPath, '/notes/original-name/');
+	assert.equal(toMarkdownPath(urlPath), 'notes/original-name.md');
+});
+
+test('nested content keeps its directories', () => {
+	assert.equal(toMarkdownPath('/notes/series/part-one/'), 'notes/series/part-one.md');
+});
+
+test('a relative segment is refused rather than normalized', () => {
+	// `url` is author-controlled frontmatter, and joining `..` onto the output
+	// directory would write outside the build.
+	assert.throws(() => toMarkdownPath('/notes/../../etc/passwd/'), /relative segment/);
+});
+
+describe('the built site', () => {
+	before(async () => {
+		const require = createRequire(import.meta.url);
+		const manifest = require.resolve('astro/package.json');
+		const astro = path.join(path.dirname(manifest), require(manifest).bin.astro);
+
+		await run(process.execPath, [astro, 'build'], { cwd: ROOT, maxBuffer: 16 * 1024 * 1024 });
+	});
+
+	test('serves the .md byte-identical to the source file', async () => {
+		const built = await readFile(path.join(DIST, 'notes', 'atomic-notes.md'));
+		const source = await readFile(path.join(ROOT, 'src/content/notes/Atomic Notes.md'));
+
+		assert.deepEqual(built, source);
+	});
+
+	test('serves every entry the graph sees as markdown too', async () => {
+		const entries = await loadContentEntries();
+
+		assert.ok(entries.length > 0);
+
+		for (const entry of entries) {
+			const built = await readFile(path.join(DIST, toMarkdownPath(entry.urlPath)));
+			const source = await readFile(path.join(ROOT, entry.file));
+
+			assert.deepEqual(built, source, `${entry.urlPath} does not match ${entry.file}`);
+		}
+	});
+});


### PR DESCRIPTION
Engine half of #31. One URL per note, two representations: `/notes/atomic-notes/` renders the page, `/notes/atomic-notes.md` returns the source file, frontmatter and wikilinks untouched.

- `astro.backlinks.ts`: on `astro:build:done`, every content entry's source is written verbatim to `dist/<urlPath>.md` (`/` → `index.md`). Thin writer beside `writeBacklinksFile`, paths via `fileURLToPath`.
- `src/lib/graph.ts`: one pure helper mapping `urlPath` to the dist path.
- `src/components/MarkdownLink.astro`: a plain text "view as markdown" link on note, research and page templates.
- `tests/markdown-urls.test.mjs`: path mapping for notes, research, root and a pinned slug; and a build test that every entry's `.md` twin is byte-identical to its source.

Receipt at `e570c77` (rebased on `84b0ce1`): 87 tests pass (was 79), `pnpm build` green, `public/backlinks.json` byte-identical, 10 of 10 notes have a `.md` twin, `diff dist/notes/atomic-notes.md "src/content/notes/Atomic Notes.md"` empty.

Not in this PR (engine has no such files): `llms.txt` routes. Harness half (#31 steps 5–6) notes from the lane: Cloudflare Pages must serve `.md` as `text/markdown` (check with `curl -I`, add a `_headers` rule if not); catch-all redirect rules must not shadow `/notes/*.md`; the `updates` collection is not in `CONTENT_DIRS`, so it gets no twin until that changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1XXFXAsDP1ftHkaRbgwwz