### PR TITLE
feat: graph related matches dictation, graph query --unreferenced, and commune render

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,8 @@ commune graph query --recent 7d
 commune update --recent 7d
 commune graph related src/content/notes/hello.md
 echo "a rough dump that mentions World" | commune graph related -
+commune render src/content/notes/hello.md
+echo '[[World]]' | commune render -
 commune gate
 ```
 
@@ -244,6 +246,7 @@ commune gate
 | --- | --- |
 | `graph query` | Every entry with its edges and dates. Filter with `--collection`, `--tag`, `--status`, `--orphans`, `--deadends`, `--unreferenced`, `--recent`. |
 | `graph related <path\|text\|->` | What this connects to. It takes stdin, so you can ask about a draft before it is a note. Titles are matched across whitespace and case, so a dictated "noon tide" still finds `Noontide`. |
+| `render <path\|->` | The markdown as HTML, through the site's own pipeline: WikiLinks resolved, external links marked. Takes stdin, so you can see a draft before it is a page. |
 | `update` | Scaffold a dated update entry from what changed. Prints it; `--write` files it. |
 | `check` | Broken links, duplicate names, ambiguous targets, non-canonical titles. |
 | `gate` | Run after a build, against the built site. |
@@ -253,6 +256,8 @@ commune gate
 `--recent` takes `7d`, `2w` or a date, and reports the day it resolved to in the summary — which is what a weekly update job needs, since `7d` means a different day tomorrow. Entries with no date at all are not returned: "unchanged since Monday" and "nobody knows" are different answers.
 
 Every verb takes `--json` and emits one document on stdout with everything else on stderr. The human-readable text is the fallback rendering; the JSON is the contract.
+
+`render` is the site's own markdown processor with no Astro process around it — the same `communeMarkdown()` the config hands to `markdown.processor`, so the HTML is the page's HTML rather than a lookalike. It needs the site's origin to decide which links are external: `--site` says it, and without one the Astro config is read for a `site` declaration, falling back to `https://example.com` with a line on stderr saying so. `--json` adds the document's links and the names among them that resolve to nothing, which the HTML cannot tell you — an unresolved WikiLink renders as plain text, exactly as it does on the site.
 
 `update` is the only verb that can write, and it only does so when asked: without `--write` the entry goes to stdout, and with it the command refuses to overwrite an update that already exists. `summary` comes out empty — summarizing a week is a judgement, and the CLI has none.
 

--- a/README.md
+++ b/README.md
@@ -242,11 +242,13 @@ commune gate
 
 | Verb | What it answers |
 | --- | --- |
-| `graph query` | Every entry with its edges and dates. Filter with `--collection`, `--tag`, `--status`, `--orphans`, `--deadends`, `--recent`. |
+| `graph query` | Every entry with its edges and dates. Filter with `--collection`, `--tag`, `--status`, `--orphans`, `--deadends`, `--unreferenced`, `--recent`. |
 | `graph related <path\|text\|->` | What this connects to. It takes stdin, so you can ask about a draft before it is a note. Titles are matched across whitespace and case, so a dictated "noon tide" still finds `Noontide`. |
 | `update` | Scaffold a dated update entry from what changed. Prints it; `--write` files it. |
 | `check` | Broken links, duplicate names, ambiguous targets, non-canonical titles. |
 | `gate` | Run after a build, against the built site. |
+
+`--orphans` and `--unreferenced` are different questions and it is worth knowing which one you are asking. An orphan is *isolated* — nothing links to it and it links nowhere — which on a wiki where most notes link out returns almost nothing. `--unreferenced` is zero inbound with any outbound: the note you wrote, cited three others from, and never linked back to from anywhere. `updates` entries are left out of it, since a dated changelog entry is expected to have nothing pointing at it; `--collection updates` is how you say you meant them.
 
 `--recent` takes `7d`, `2w` or a date, and reports the day it resolved to in the summary — which is what a weekly update job needs, since `7d` means a different day tomorrow. Entries with no date at all are not returned: "unchanged since Monday" and "nobody knows" are different answers.
 

--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ commune gate
 | Verb | What it answers |
 | --- | --- |
 | `graph query` | Every entry with its edges and dates. Filter with `--collection`, `--tag`, `--status`, `--orphans`, `--deadends`, `--recent`. |
-| `graph related <path\|text\|->` | What this connects to. It takes stdin, so you can ask about a draft before it is a note. |
+| `graph related <path\|text\|->` | What this connects to. It takes stdin, so you can ask about a draft before it is a note. Titles are matched across whitespace and case, so a dictated "noon tide" still finds `Noontide`. |
 | `update` | Scaffold a dated update entry from what changed. Prints it; `--write` files it. |
 | `check` | Broken links, duplicate names, ambiguous targets, non-canonical titles. |
 | `gate` | Run after a build, against the built site. |

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -18,7 +18,7 @@ import {
 	type Diagnostic,
 	type DiagnosticRule,
 } from '../lib/graph.ts';
-import { SCHEMA, writeJson, writeLines } from './render.ts';
+import { SCHEMA, writeJson, writeLines } from './output.ts';
 import { EXIT_OK } from './errors.ts';
 
 const RULES: DiagnosticRule[] = [

--- a/src/cli/gate.ts
+++ b/src/cli/gate.ts
@@ -36,7 +36,7 @@ import {
 	type ContentEntry,
 } from '../lib/graph.ts';
 import { EXIT_FAILED, EXIT_OK, failure } from './errors.ts';
-import { SCHEMA, writeJson } from './render.ts';
+import { SCHEMA, writeJson } from './output.ts';
 
 /** Which assertion failed, and what it saw. */
 export interface GateFailure {

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -15,7 +15,7 @@
 import { parseArgs } from 'node:util';
 import type { ParseArgsOptionsConfig } from 'node:util';
 import { CliError, EXIT_OK, EXIT_USAGE, isParseArgsError, usageError } from './errors.ts';
-import { writeError } from './render.ts';
+import { writeError } from './output.ts';
 import { resolveRoot } from './root.ts';
 import { toIsoDay } from '../lib/graph.ts';
 import { parseRecent, queryCommand, type QueryFilters } from './query.ts';
@@ -50,13 +50,18 @@ const UPDATE_OPTIONS: ParseArgsOptionsConfig = {
 	write: { type: 'boolean', default: false },
 };
 
+const RENDER_OPTIONS: ParseArgsOptionsConfig = {
+	...GLOBAL,
+	site: { type: 'string' },
+};
+
 const GATE_OPTIONS: ParseArgsOptionsConfig = {
 	...GLOBAL,
 	dist: { type: 'string' },
 };
 
 /** Every route, longest first, so `graph query` is matched before a bare `graph`. */
-const ROUTES = ['graph query', 'graph related', 'check', 'gate', 'update'];
+const ROUTES = ['graph query', 'graph related', 'check', 'gate', 'update', 'render'];
 
 interface Route {
 	name: string;
@@ -176,6 +181,42 @@ async function dispatch(args: string[]): Promise<number> {
 			return relatedCommand(
 				await resolveRoot(values.root as string | undefined),
 				positionals[0],
+				values.json as boolean
+			);
+		}
+		case 'render': {
+			const { values, positionals } = parseStrict(rest, RENDER_OPTIONS, true, usage);
+			if (values.help) {
+				process.stdout.write(`${usage}\n`);
+				return EXIT_OK;
+			}
+			if (positionals.length !== 1) {
+				throw usageError(
+					positionals.length
+						? `render takes one argument, got ${positionals.length}: ${positionals.join(' ')}. A path containing spaces has to be quoted.`
+						: 'render needs a path to a markdown file, or - for stdin',
+					usage
+				);
+			}
+			const site = values.site as string | undefined;
+			// Checked here rather than where it is used, so a typo is exit 2
+			// beside every other bad flag instead of an internal error from the
+			// URL parse three calls deeper.
+			if (site !== undefined && !URL.canParse(site)) {
+				throw usageError(`--site takes an origin like https://example.com, not ${site}`, usage);
+			}
+			// Imported here rather than at the top of the file: `render` is the
+			// one verb that needs the markdown pipeline, and
+			// `@astrojs/markdown-remark` is a peer dependency. A static import
+			// would make every other verb load it — a startup cost on every
+			// `check`, and an outright failure in a project that has the CLI but
+			// not the renderer, which is the opposite of the promise the rest of
+			// this CLI makes about running without Astro.
+			const { renderCommand } = await import('./render.ts');
+			return renderCommand(
+				await resolveRoot(values.root as string | undefined),
+				positionals[0],
+				site,
 				values.json as boolean
 			);
 		}

--- a/src/cli/main.ts
+++ b/src/cli/main.ts
@@ -40,6 +40,7 @@ const QUERY_OPTIONS: ParseArgsOptionsConfig = {
 	status: { type: 'string' },
 	orphans: { type: 'boolean', default: false },
 	deadends: { type: 'boolean', default: false },
+	unreferenced: { type: 'boolean', default: false },
 	recent: { type: 'string' },
 };
 
@@ -153,6 +154,7 @@ async function dispatch(args: string[]): Promise<number> {
 				status: values.status as string | undefined,
 				orphans: values.orphans as boolean,
 				deadends: values.deadends as boolean,
+				unreferenced: values.unreferenced as boolean,
 				...(since !== undefined ? { since } : {}),
 			};
 			return queryCommand(await resolveRoot(values.root as string | undefined), filters, values.json as boolean);

--- a/src/cli/output.ts
+++ b/src/cli/output.ts
@@ -1,0 +1,39 @@
+/**
+ * How a command's result reaches the caller.
+ *
+ * One rule, and everything else follows from it: in `--json` mode stdout holds
+ * exactly one JSON document and nothing else. Progress, warnings and errors go
+ * to stderr, so `commune check --json > findings.json` yields a parseable file
+ * even on the run that fails.
+ */
+
+import type { CliError } from './errors.ts';
+
+/** Every payload carries the contract version, so #10's skills can pin it. */
+export const SCHEMA = 1;
+
+export function writeJson(payload: unknown): void {
+	process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
+}
+
+export function writeLines(lines: string[]): void {
+	if (lines.length) process.stdout.write(lines.join('\n') + '\n');
+}
+
+/**
+ * Render a failure, on stderr, in whichever mode the caller asked for.
+ *
+ * `json` is read from the raw argv rather than the parsed options, because the
+ * errors most worth rendering as JSON are the ones thrown while parsing.
+ */
+export function writeError(error: CliError, json: boolean): void {
+	if (json) {
+		process.stderr.write(
+			JSON.stringify({ error: { code: error.code, message: error.message } }, null, 2) + '\n'
+		);
+		return;
+	}
+
+	process.stderr.write(`commune: ${error.message}\n`);
+	if (error.detail) process.stderr.write(`${error.detail}\n`);
+}

--- a/src/cli/query.ts
+++ b/src/cli/query.ts
@@ -16,7 +16,7 @@ import {
 	type DateSource,
 	type Graph,
 } from '../lib/graph.ts';
-import { SCHEMA, writeJson, writeLines } from './render.ts';
+import { SCHEMA, writeJson, writeLines } from './output.ts';
 import { EXIT_OK } from './errors.ts';
 
 export interface QueryFilters {

--- a/src/cli/query.ts
+++ b/src/cli/query.ts
@@ -25,6 +25,7 @@ export interface QueryFilters {
 	status?: string;
 	orphans: boolean;
 	deadends: boolean;
+	unreferenced: boolean;
 	/** Inclusive `yyyy-mm-dd` cutoff from `--recent`. Entries older than it, and
 	 *  entries with no date at all, are not returned. */
 	since?: string;
@@ -116,6 +117,20 @@ function isDeadend(entry: QueryEntry): boolean {
 }
 
 /**
+ * Nobody links here. Whether it links *out* is a separate question.
+ *
+ * The other half of the orphan split, and the half the connect step actually
+ * wants: a note that cites three others but that nothing cites back is not
+ * isolated, it is unplaced — and a wiki accumulates those silently, because
+ * writing a note is the moment you think about its outbound links and never
+ * about its inbound ones. `--orphans` returns 0 on a vault like that, which is
+ * the true answer to a different question.
+ */
+function isUnreferenced(entry: QueryEntry): boolean {
+	return entry.inbound.length === 0;
+}
+
+/**
  * Repeated values of one flag widen the match; different flags narrow it.
  *
  * `--collection notes --collection pages --tag seed` means "a note or a page,
@@ -128,6 +143,15 @@ function matches(entry: QueryEntry, filters: QueryFilters): boolean {
 	if (filters.status !== undefined && entry.status !== filters.status) return false;
 	if (filters.orphans && !isOrphan(entry)) return false;
 	if (filters.deadends && !isDeadend(entry)) return false;
+	if (filters.unreferenced) {
+		if (!isUnreferenced(entry)) return false;
+		// A dated changelog entry is *expected* to have nothing pointing at it,
+		// so leaving `updates` in would bury the notes this filter exists to
+		// surface under one row per week. Asking for the collection by name is
+		// the way to say you meant it — and it is the only way, so the exclusion
+		// can never quietly hide an answer somebody asked for.
+		if (entry.collection === 'updates' && !filters.collections.includes('updates')) return false;
+	}
 	// An entry with no date is not "unchanged since the cutoff", it is unknown —
 	// and a list of what changed this week is worth less with unknowns in it.
 	if (filters.since !== undefined && !(entry.updated && entry.updated >= filters.since)) {
@@ -154,6 +178,12 @@ function summarize(results: QueryEntry[], since?: string) {
 		edges: results.reduce((total, entry) => total + entry.outbound.length, 0),
 		orphans: results.filter(isOrphan).length,
 		deadends: results.filter(isDeadend).length,
+		// Counted over what came back, like every other number here, so it can
+		// never contradict `entries` beside it. Note that on an *unfiltered*
+		// query this includes `updates` entries — the exclusion belongs to
+		// `--unreferenced` the filter, not to "has nothing pointing at it" the
+		// property.
+		unreferenced: results.filter(isUnreferenced).length,
 		// The resolved cutoff, not the string the caller typed: `--recent 7d`
 		// means a different day tomorrow, and a job that records what it asked
 		// needs the day, not the duration.
@@ -187,7 +217,7 @@ export async function queryCommand(
 				`→${entry.outbound.length} ←${entry.inbound.length}`
 		),
 		`${summary.entries} entries, ${summary.edges} edges, ${summary.orphans} orphans, ` +
-			`${summary.deadends} dead ends` +
+			`${summary.deadends} dead ends, ${summary.unreferenced} unreferenced` +
 			(summary.since !== undefined ? `, updated since ${summary.since}` : ''),
 	]);
 	return EXIT_OK;

--- a/src/cli/related.ts
+++ b/src/cli/related.ts
@@ -12,7 +12,10 @@
  *
  * Fuzzy and semantic similarity are out of scope on purpose. They are product
  * direction, not a build decision, and inventing a ranking here would freeze it
- * into the contract before anyone chose it.
+ * into the contract before anyone chose it. What #69 added is not similarity:
+ * whitespace inside a name is not information, so a dictated "noon tide" and a
+ * written `Noontide` are the same name spelled two ways, and matching them is
+ * still an exact match — just of the right string.
  */
 
 import { readFile, stat } from 'node:fs/promises';
@@ -32,7 +35,10 @@ import {
 import { SCHEMA, writeJson, writeLines } from './render.ts';
 import { EXIT_OK, failure } from './errors.ts';
 
-/** Shortest name worth matching. Below this, a mention is noise. */
+/**
+ * Shortest name worth matching, measured after normalisation. Below this, a
+ * mention is noise — `B` would make every capital B a connection.
+ */
 const MIN_MENTION_LENGTH = 3;
 
 interface Reference {
@@ -121,21 +127,96 @@ async function readStdin(): Promise<string> {
 	return Buffer.concat(chunks).toString('utf8');
 }
 
-/** Escape a title so it can be matched literally: real titles contain `,`, `'`, `(`. */
-function escapeRegExp(value: string): string {
-	return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+const WHITESPACE = /\s/;
+const WORD = /\w/;
+
+/** A string reduced to the form names are matched in, with a way back. */
+interface Normalized {
+	/** Lowercased, with every whitespace character removed. */
+	text: string;
+	/** For each character of `text`, the index it came from in the original. */
+	offsets: number[];
 }
 
 /**
- * Count whole-word occurrences of `name` in `text`.
+ * Reduce a string to the form mentions are matched in.
  *
- * Lookarounds rather than `\b`, because `\b` is defined relative to the
- * character next to it: a title ending in `?` or `)` puts a non-word character
- * where `\b` expects a word one, and the match silently stops happening.
+ * Whitespace is removed rather than collapsed, which is what makes "noon tide"
+ * and `Noontide` the same string — the distortion dictation reliably produces
+ * (#69), and the reason a whole-word matcher over the raw text missed the
+ * titles it most needed to find. The offsets are what keep the answer honest:
+ * the word boundaries removed *inside* a name are still there in the original
+ * at its *edges*, so `Cake` can be found in "pan cake" and refused in
+ * "pancake".
+ *
+ * Built one output character at a time because `toLowerCase()` is not always
+ * length-preserving (`'İ'.toLowerCase()` is two code units), and one offset per
+ * emitted unit is what keeps the map exact for any input.
  */
-function countMentions(text: string, name: string): number {
-	const pattern = new RegExp(`(?<!\\w)${escapeRegExp(name)}(?!\\w)`, 'gi');
-	return text.match(pattern)?.length ?? 0;
+function normalize(text: string): Normalized {
+	let normalized = '';
+	const offsets: number[] = [];
+
+	for (let index = 0; index < text.length; index += 1) {
+		const char = text[index];
+		if (WHITESPACE.test(char)) continue;
+		const lowered = char.toLowerCase();
+		for (let unit = 0; unit < lowered.length; unit += 1) {
+			normalized += lowered[unit];
+			offsets.push(index);
+		}
+	}
+
+	return { text: normalized, offsets };
+}
+
+/** How often a name occurs in the prose, and how it was spelled the first time. */
+interface Hits {
+	count: number;
+	/** The surface form as it appeared, lowercased and with runs of whitespace collapsed. */
+	matched?: string;
+}
+
+/**
+ * Find every whole-word occurrence of `name`, across whitespace and case.
+ *
+ * The search runs on the normalised text and the boundary check on the original,
+ * because the two questions want different strings: "is this the same name"
+ * ignores the spaces, "is this a whole word" is only about the characters
+ * outside it. A character index either side is enough — `\w` is asked directly
+ * rather than through `\b`, which is defined relative to its neighbour and so
+ * silently stops matching a title that ends in `?` or `)`.
+ */
+function findMentions(prose: string, haystack: Normalized, name: string): Hits {
+	const needle = normalize(name).text;
+	if (needle.length < MIN_MENTION_LENGTH) return { count: 0 };
+
+	let count = 0;
+	let matched: string | undefined;
+
+	for (
+		let at = haystack.text.indexOf(needle);
+		at !== -1;
+		at = haystack.text.indexOf(needle, at + 1)
+	) {
+		const start = haystack.offsets[at];
+		const end = haystack.offsets[at + needle.length - 1];
+		if (WORD.test(prose[start - 1] ?? '')) continue;
+		if (WORD.test(prose[end + 1] ?? '')) continue;
+
+		count += 1;
+		// The surface form, not the title: the connect step offers the candidate
+		// back with the words Devon actually said, so he can see which phrase in
+		// his dump the link would replace. Lowercased because that is what the
+		// field has always carried, and case is not what distinguishes one
+		// surface form from another here.
+		matched ??= prose
+			.slice(start, end + 1)
+			.toLowerCase()
+			.replace(/\s+/g, ' ');
+	}
+
+	return { count, matched };
 }
 
 export async function relatedCommand(root: string, input: string, json: boolean): Promise<number> {
@@ -161,19 +242,17 @@ export async function relatedCommand(root: string, input: string, json: boolean)
 	});
 
 	const prose = stripCode(source.text);
+	const haystack = normalize(prose);
 	const mentions = entries
 		.filter((entry) => entry.urlPath !== self?.urlPath)
 		.map((entry) => {
-			const names = [entry.title, ...entry.aliases].filter(
-				(name) => name.length >= MIN_MENTION_LENGTH
-			);
 			let count = 0;
 			let matched: string | undefined;
-			for (const name of names) {
-				const hits = countMentions(prose, name);
-				if (!hits) continue;
-				count += hits;
-				matched ??= name.toLowerCase();
+			for (const name of [entry.title, ...entry.aliases]) {
+				const hits = findMentions(prose, haystack, name);
+				if (!hits.count) continue;
+				count += hits.count;
+				matched ??= hits.matched;
 			}
 			return { ...toReference(entry), matched, count };
 		})

--- a/src/cli/related.ts
+++ b/src/cli/related.ts
@@ -18,9 +18,6 @@
  * still an exact match — just of the right string.
  */
 
-import { readFile, stat } from 'node:fs/promises';
-import path from 'node:path';
-import matter from 'gray-matter';
 import {
 	buildGraph,
 	buildLinkLookup,
@@ -32,8 +29,9 @@ import {
 	type CollectionName,
 	type ContentEntry,
 } from '../lib/graph.ts';
-import { SCHEMA, writeJson, writeLines } from './render.ts';
-import { EXIT_OK, failure } from './errors.ts';
+import { SCHEMA, writeJson, writeLines } from './output.ts';
+import { EXIT_OK } from './errors.ts';
+import { readSource } from './source.ts';
 
 /**
  * Shortest name worth matching, measured after normalisation. Below this, a
@@ -48,14 +46,6 @@ interface Reference {
 	file: string;
 }
 
-interface Source {
-	kind: 'file' | 'text' | 'stdin';
-	file?: string;
-	urlPath?: string;
-	text: string;
-	frontmatter: Record<string, unknown>;
-}
-
 function toReference(entry: ContentEntry): Reference {
 	return {
 		urlPath: entry.urlPath,
@@ -63,68 +53,6 @@ function toReference(entry: ContentEntry): Reference {
 		collection: entry.collection,
 		file: entry.file,
 	};
-}
-
-/**
- * Work out whether the positional is a path, stdin, or literal prose.
- *
- * A path is tried against the root before the cwd, because the root is the
- * vault being asked about and the cwd is wherever the operator happens to be
- * standing. `-` is stdin, which is how a draft that is not a file yet gets
- * asked "what does this connect to".
- */
-async function readSource(input: string, root: string): Promise<Source> {
-	if (input === '-') {
-		const text = await readStdin();
-		const { content, data } = matter(text);
-		return { kind: 'stdin', text: content, frontmatter: data };
-	}
-
-	const candidates = path.isAbsolute(input)
-		? [input]
-		: [path.join(root, input), path.resolve(input)];
-
-	for (const candidate of candidates) {
-		if (!(await isFile(candidate))) continue;
-
-		let source: string;
-		try {
-			source = await readFile(candidate, 'utf8');
-		} catch (error) {
-			throw failure('EPARSE', `cannot read ${candidate}: ${(error as Error).message}`);
-		}
-
-		let parsed;
-		try {
-			parsed = matter(source);
-		} catch (error) {
-			throw failure('EPARSE', `cannot parse frontmatter in ${candidate}: ${(error as Error).message}`);
-		}
-
-		const relative = path.relative(root, candidate).split(path.sep).join('/');
-		return {
-			kind: 'file',
-			file: relative,
-			text: parsed.content,
-			frontmatter: parsed.data,
-		};
-	}
-
-	return { kind: 'text', text: input, frontmatter: {} };
-}
-
-async function isFile(candidate: string): Promise<boolean> {
-	try {
-		return (await stat(candidate)).isFile();
-	} catch {
-		return false;
-	}
-}
-
-async function readStdin(): Promise<string> {
-	const chunks: Buffer[] = [];
-	for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
-	return Buffer.concat(chunks).toString('utf8');
 }
 
 const WHITESPACE = /\s/;
@@ -226,7 +154,7 @@ export async function relatedCommand(root: string, input: string, json: boolean)
 	const byUrl = buildUrlLookup(entries);
 	const byUrlPath = new Map(entries.map((entry) => [entry.urlPath, entry]));
 
-	const source = await readSource(input, root);
+	const source = await readSource(input, root, { allowText: true });
 	// A file that happens to be a graph entry gets its inbound links too; a
 	// draft outside the vault, or raw text, has none by definition.
 	const self = source.file ? entries.find((entry) => entry.file === source.file) : undefined;

--- a/src/cli/render.ts
+++ b/src/cli/render.ts
@@ -1,39 +1,95 @@
 /**
- * How a command's result reaches the caller.
+ * `commune render` — a draft as the site will render it.
  *
- * One rule, and everything else follows from it: in `--json` mode stdout holds
- * exactly one JSON document and nothing else. Progress, warnings and errors go
- * to stderr, so `commune check --json > findings.json` yields a parseable file
- * even on the run that fails.
+ * The review surface the map listed as "not yet specified" needs one thing the
+ * rest of the CLI does not provide: the actual HTML, with `[[WikiLinks]]`
+ * resolved against the real content tree and external links marked, for a
+ * document that is not a page yet and may never be committed. Astro can produce
+ * that, but only by building the whole site, which is a per-turn cost nobody
+ * pays to look at one paragraph.
+ *
+ * So the pipeline is borrowed rather than reimplemented: `communeMarkdown` is
+ * the same processor `astro.config.mjs` hands to `markdown.processor`, and this
+ * verb drives it directly. The rule that keeps it honest is that this file adds
+ * no plugin, no option and no post-processing of its own — anything that made
+ * the CLI's HTML differ from the site's would make the review surface a liar.
+ *
+ * `links` and `unresolved` come from the graph core rather than from the
+ * rendered tree. An unresolved wikilink renders as plain text on purpose, so by
+ * the time there is HTML the broken link is indistinguishable from a sentence,
+ * and the one thing a reviewer most needs to be told is gone.
  */
 
-import type { CliError } from './errors.ts';
+import { communeMarkdown } from '../markdown.ts';
+import {
+	buildLinkLookup,
+	buildUrlLookup,
+	extractLinks,
+	loadContentEntries,
+	resolveLink,
+} from '../lib/graph.ts';
+import { SCHEMA, writeJson } from './output.ts';
+import { EXIT_OK } from './errors.ts';
+import { readSource } from './source.ts';
+import { resolveSite } from './site.ts';
 
-/** Every payload carries the contract version, so #10's skills can pin it. */
-export const SCHEMA = 1;
+export async function renderCommand(
+	root: string,
+	input: string,
+	siteFlag: string | undefined,
+	json: boolean
+): Promise<number> {
+	// Read before anything else: `-` has to consume stdin before a slow scan of
+	// the content tree, or a producer writing into the pipe waits on us.
+	const source = await readSource(input, root, { allowText: false });
+	const { site, source: siteSource } = await resolveSite(siteFlag, root);
 
-export function writeJson(payload: unknown): void {
-	process.stdout.write(JSON.stringify(payload, null, 2) + '\n');
-}
-
-export function writeLines(lines: string[]): void {
-	if (lines.length) process.stdout.write(lines.join('\n') + '\n');
-}
-
-/**
- * Render a failure, on stderr, in whichever mode the caller asked for.
- *
- * `json` is read from the raw argv rather than the parsed options, because the
- * errors most worth rendering as JSON are the ones thrown while parsing.
- */
-export function writeError(error: CliError, json: boolean): void {
-	if (json) {
+	if (siteSource === 'default') {
+		// On stderr, and only when nothing named an origin: `site` decides which
+		// links are the wiki's own, so a caller who did not supply one is
+		// looking at every absolute link marked external and deserves to know
+		// why. In `--json` the field says it too, without the noise.
 		process.stderr.write(
-			JSON.stringify({ error: { code: error.code, message: error.message } }, null, 2) + '\n'
+			`commune: no --site and none found in the Astro config; rendering against ${site}, ` +
+				`so every absolute link counts as external\n`
 		);
-		return;
 	}
 
-	process.stderr.write(`commune: ${error.message}\n`);
-	if (error.detail) process.stderr.write(`${error.detail}\n`);
+	const entries = await loadContentEntries({ root });
+	const byName = buildLinkLookup(entries);
+	const byUrl = buildUrlLookup(entries);
+	const byUrlPath = new Map(entries.map((entry) => [entry.urlPath, entry]));
+
+	const links = extractLinks(source.text, source.frontmatter).map((link) => {
+		const target = resolveLink(link, byName, byUrl);
+		const entry = target ? byUrlPath.get(target.urlPath) : undefined;
+		return {
+			kind: link.kind,
+			target: link.target,
+			resolved: entry
+				? { urlPath: entry.urlPath, title: entry.title, collection: entry.collection }
+				: null,
+		};
+	});
+
+	const renderer = await communeMarkdown({ site, root }).createRenderer({});
+	const { code } = await renderer.render(source.text, { frontmatter: source.frontmatter });
+
+	if (json) {
+		writeJson({
+			schema: SCHEMA,
+			root,
+			site,
+			source: { kind: source.kind, ...(source.file ? { file: source.file } : {}) },
+			html: code,
+			links,
+			// The projection a reviewer acts on: the names in the draft that
+			// point at nothing, which the HTML has already turned into prose.
+			unresolved: links.filter((link) => !link.resolved).map((link) => link.target),
+		});
+		return EXIT_OK;
+	}
+
+	process.stdout.write(code.endsWith('\n') ? code : `${code}\n`);
+	return EXIT_OK;
 }

--- a/src/cli/site.ts
+++ b/src/cli/site.ts
@@ -1,0 +1,70 @@
+/**
+ * Finding the site's own origin, without starting Astro.
+ *
+ * `site` is what tells the rehype plugin which links are the wiki's own, so
+ * rendering with the wrong one marks every internal absolute link as external.
+ * The value lives in the consumer's `astro.config.*` — but importing that file
+ * would load Astro, the integrations and whatever else the config pulls in,
+ * which is exactly the process this CLI exists to avoid, and would execute the
+ * consumer's code to answer a question about a string.
+ *
+ * So the config is read as text and searched for the two spellings that
+ * actually occur: the property inside `defineConfig`, and the `const` above it
+ * that the property is a shorthand for. Both real wikis use the second. This is
+ * a best effort by construction: `--site` overrides it, and when neither
+ * produces an answer the fallback is announced on stderr rather than assumed.
+ */
+
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+/**
+ * The origin used when nothing else names one.
+ *
+ * A reserved example domain, so a link to it can never collide with a real
+ * host: with this in force, every absolute link renders as external, which is
+ * the safe way to be wrong.
+ */
+export const DEFAULT_SITE = 'https://example.com';
+
+const CONFIG_FILES = ['astro.config.mjs', 'astro.config.js', 'astro.config.ts', 'astro.config.mts'];
+
+/** `site: 'https://…'` inside the config object, or `const site = 'https://…'` above it. */
+const SITE_PATTERNS = [/\bsite\s*:\s*['"`]([^'"`]+)['"`]/, /\bsite\s*=\s*['"`]([^'"`]+)['"`]/];
+
+export type SiteSource = 'flag' | 'config' | 'default';
+
+export interface ResolvedSite {
+	site: string;
+	source: SiteSource;
+}
+
+/** Read `site` out of a project's Astro config, if it declares one this way. */
+async function readSiteFromConfig(root: string): Promise<string | undefined> {
+	for (const name of CONFIG_FILES) {
+		let source: string;
+		try {
+			source = await readFile(path.join(root, name), 'utf8');
+		} catch {
+			continue;
+		}
+
+		for (const pattern of SITE_PATTERNS) {
+			const value = pattern.exec(source)?.[1];
+			// Only a real origin: `site: undefined` and a templated string are
+			// both better answered by the default than by a guess.
+			if (value && URL.canParse(value)) return value;
+		}
+	}
+
+	return undefined;
+}
+
+export async function resolveSite(flag: string | undefined, root: string): Promise<ResolvedSite> {
+	if (flag !== undefined) return { site: flag, source: 'flag' };
+
+	const configured = await readSiteFromConfig(root);
+	if (configured !== undefined) return { site: configured, source: 'config' };
+
+	return { site: DEFAULT_SITE, source: 'default' };
+}

--- a/src/cli/source.ts
+++ b/src/cli/source.ts
@@ -1,0 +1,101 @@
+/**
+ * Where a verb's markdown comes from: a file, stdin, or the argument itself.
+ *
+ * One reader for `graph related` and `render`, because they take the same
+ * positional and have to agree about what it means — including the part that is
+ * easy to get subtly different, which is that a path is tried against `--root`
+ * before the cwd. The root is the vault being asked about; the cwd is wherever
+ * the operator happens to be standing.
+ *
+ * The one difference between the two callers is what a string that names no
+ * file means. `graph related` answers questions about prose, so it is text.
+ * `render` renders a document, and a mistyped path silently rendering as its
+ * own filename would be a wrong answer with no error anywhere, so it fails.
+ */
+
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import matter from 'gray-matter';
+import { failure } from './errors.ts';
+
+export interface Source {
+	kind: 'file' | 'text' | 'stdin';
+	/** Root-relative and POSIX-separated, for a file. */
+	file?: string;
+	/** The markdown body, with any frontmatter split off. */
+	text: string;
+	frontmatter: Record<string, unknown>;
+}
+
+export interface ReadSourceOptions {
+	/** Whether a string naming no file is prose (`graph related`) or an error (`render`). */
+	allowText: boolean;
+}
+
+async function isFile(candidate: string): Promise<boolean> {
+	try {
+		return (await stat(candidate)).isFile();
+	} catch {
+		return false;
+	}
+}
+
+async function readStdin(): Promise<string> {
+	const chunks: Buffer[] = [];
+	for await (const chunk of process.stdin) chunks.push(chunk as Buffer);
+	return Buffer.concat(chunks).toString('utf8');
+}
+
+/**
+ * Resolve the positional into markdown and its frontmatter.
+ *
+ * `-` is stdin, which is how a draft that is not a file yet gets asked about —
+ * and it is frontmatter-aware there too, so piping a whole note in behaves the
+ * same as naming it.
+ */
+export async function readSource(
+	input: string,
+	root: string,
+	{ allowText }: ReadSourceOptions
+): Promise<Source> {
+	if (input === '-') {
+		const { content, data } = matter(await readStdin());
+		return { kind: 'stdin', text: content, frontmatter: data };
+	}
+
+	const candidates = path.isAbsolute(input) ? [input] : [path.join(root, input), path.resolve(input)];
+
+	for (const candidate of candidates) {
+		if (!(await isFile(candidate))) continue;
+
+		let source: string;
+		try {
+			source = await readFile(candidate, 'utf8');
+		} catch (error) {
+			throw failure('EPARSE', `cannot read ${candidate}: ${(error as Error).message}`);
+		}
+
+		let parsed;
+		try {
+			parsed = matter(source);
+		} catch (error) {
+			throw failure(
+				'EPARSE',
+				`cannot parse frontmatter in ${candidate}: ${(error as Error).message}`
+			);
+		}
+
+		return {
+			kind: 'file',
+			file: path.relative(root, candidate).split(path.sep).join('/'),
+			text: parsed.content,
+			frontmatter: parsed.data,
+		};
+	}
+
+	if (!allowText) {
+		throw failure('EPARSE', `cannot read ${input}: no such file under ${root} or the cwd`);
+	}
+
+	return { kind: 'text', text: input, frontmatter: {} };
+}

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -17,7 +17,7 @@
 import { mkdir, stat, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { CONTENT_DIRS, loadContentEntries, type ContentEntry } from '../lib/graph.ts';
-import { SCHEMA, writeJson, writeLines } from './render.ts';
+import { SCHEMA, writeJson, writeLines } from './output.ts';
 import { EXIT_OK, failure } from './errors.ts';
 
 /**

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -22,6 +22,10 @@ graph query filters (any-of within a flag, all-of across flags):
   --status <status>
   --orphans                                     Zero inbound and zero outbound.
   --deadends                                    Zero outbound.
+  --unreferenced                                Zero inbound, any outbound. Skips
+                                                updates, which are expected to have
+                                                none, unless --collection updates
+                                                asks for them.
   --recent <7d|2w|2026-09-01>                   Updated on or since then. Entries
                                                 with no date are not returned.
 
@@ -45,7 +49,7 @@ Exit codes:
 
 export const COMMAND_USAGE: Record<string, string> = {
 	'graph query':
-		'Usage: commune [--root <dir>] graph query [--collection <c>]... [--tag <t>]... [--status <s>] [--orphans] [--deadends] [--recent <duration|date>] [--json]',
+		'Usage: commune [--root <dir>] graph query [--collection <c>]... [--tag <t>]... [--status <s>] [--orphans] [--deadends] [--unreferenced] [--recent <duration|date>] [--json]',
 	'graph related':
 		'Usage: commune [--root <dir>] graph related <path|text|-> [--json]',
 	update: `Usage: commune [--root <dir>] update [--recent <duration|date>] [--write] [--json]

--- a/src/cli/usage.ts
+++ b/src/cli/usage.ts
@@ -5,6 +5,7 @@ export const USAGE = `commune — query the content graph without an Astro proce
 Usage:
   commune [--root <dir>] graph query   [filters] [--json]
   commune [--root <dir>] graph related <path|text|-> [--json]
+  commune [--root <dir>] render        <path|-> [--site <origin>] [--json]
   commune [--root <dir>] update        [--recent <duration|date>] [--write] [--json]
   commune [--root <dir>] check         [--json]
   commune [--root <dir>] gate          [--dist <dir>] [--json]
@@ -28,6 +29,11 @@ graph query filters (any-of within a flag, all-of across flags):
                                                 asks for them.
   --recent <7d|2w|2026-09-01>                   Updated on or since then. Entries
                                                 with no date are not returned.
+
+render options:
+  --site <origin>   The wiki's own origin, which is what decides whether a link
+                    is external. Read from the Astro config when it declares
+                    one; otherwise https://example.com, and it says so.
 
 update options:
   --recent <7d|2w|2026-09-01>   What to roll up. Default: 7d.
@@ -58,6 +64,13 @@ Scaffold a dated update entry from the pages that changed. The draft is
 printed on stdout unless --write is given, and --write refuses to overwrite an
 update that already exists. \`summary\` is left empty on purpose: summarizing a
 week is a judgement, and this command has none.`,
+	render: `Usage: commune [--root <dir>] render <path|-> [--site <origin>] [--json]
+
+Render markdown to HTML through the site's own pipeline, with WikiLinks
+resolved against the content tree and external links marked. Frontmatter is
+split off and not rendered. --json adds the links the document contains and
+the names among them that resolve to nothing — which the HTML cannot tell
+you, since an unresolved WikiLink renders as plain text.`,
 	check: 'Usage: commune [--root <dir>] check [--json]',
 	gate: `Usage: commune [--root <dir>] gate [--dist <dir>] [--json]
 

--- a/tests/cli.test.mjs
+++ b/tests/cli.test.mjs
@@ -229,6 +229,56 @@ test('orphans are isolated, not merely unlinked-to', async () => {
 	assert.equal(JSON.parse(deadends.stdout).count, 8);
 });
 
+test('--unreferenced is zero inbound with any outbound, and hides updates', async () => {
+	const { code, stdout } = await commune(
+		'--root', VAULT, 'graph', 'query', '--unreferenced', '--json'
+	);
+
+	assert.equal(code, 0);
+	const payload = JSON.parse(stdout);
+	// The updates entry has zero inbound too, and is the one thing missing from
+	// this list: a dated changelog entry is expected to have nothing pointing
+	// at it, so it would be noise in every answer this filter is asked for.
+	assert.deepEqual(
+		payload.entries.map((entry) => entry.urlPath),
+		[
+			'/notes/duplicate-one/',
+			'/notes/index/',
+			'/notes/isolated/',
+			'/notes/sub-dir/nested-note/',
+			'/research/isolated/',
+			'/vault-page/',
+		]
+	);
+	assert.equal(payload.summary.unreferenced, payload.count);
+});
+
+test('--collection updates is how you say you meant the changelog', async () => {
+	const { stdout } = await commune(
+		'--root', VAULT, 'graph', 'query', '--unreferenced', '--collection', 'updates', '--json'
+	);
+	const payload = JSON.parse(stdout);
+
+	assert.deepEqual(payload.entries.map((entry) => entry.urlPath), ['/updates/2026-02-14/']);
+	// Two links out and nothing in: unreferenced, and emphatically not an
+	// orphan. This entry is the difference between the two filters.
+	assert.equal(payload.summary.orphans, 0);
+	assert.equal(payload.summary.edges, 2);
+	assert.equal(payload.summary.unreferenced, 1);
+});
+
+test('summary.unreferenced counts the result set, filter or no filter', async () => {
+	const { stdout } = await commune('--root', VAULT, 'graph', 'query', '--json');
+	const { summary } = JSON.parse(stdout);
+
+	// Seven, not the six `--unreferenced` returns: the property is "nothing
+	// points here", and the updates exclusion belongs to the filter rather than
+	// to the property. Every other number in `summary` describes what came
+	// back, and this one has to as well or they stop adding up together.
+	assert.equal(summary.unreferenced, 7);
+	assert.equal(summary.orphans, 6);
+});
+
 test('query and check answer "what did I get" in the same place', async () => {
 	const query = await commune('--root', VAULT, 'graph', 'query', '--json');
 	const check = await commune('--root', VAULT, 'check', '--json');
@@ -244,7 +294,7 @@ test('query and check answer "what did I get" in the same place', async () => {
 	// deduplicated inbound on the other — which is what makes this worth pinning.
 	assert.equal(q.summary.entries, c.summary.entries);
 	assert.equal(q.summary.edges, c.summary.edges);
-	assert.deepEqual(q.summary, { entries: 12, edges: 7, orphans: 6, deadends: 8 });
+	assert.deepEqual(q.summary, { entries: 12, edges: 7, orphans: 6, deadends: 8, unreferenced: 7 });
 });
 
 test('summary describes what was returned, not the whole corpus', async () => {
@@ -258,7 +308,7 @@ test('summary describes what was returned, not the whole corpus', async () => {
 	// edge *out of the notes collection*. Degrees on each entry stay
 	// whole-graph — Alpha still reports both its inbound links — but the
 	// summary counts only what was returned.
-	assert.deepEqual(summary, { entries: 8, edges: 4, orphans: 4, deadends: 6 });
+	assert.deepEqual(summary, { entries: 8, edges: 4, orphans: 4, deadends: 6, unreferenced: 4 });
 });
 
 test('a filtered query reports itself consistently', async () => {

--- a/tests/fixtures/dictation/src/content/notes/Cake.md
+++ b/tests/fixtures/dictation/src/content/notes/Cake.md
@@ -1,0 +1,8 @@
+---
+title: Cake
+visibility: public
+status: live
+---
+
+A short title that lives inside a longer word, so the whole-word rule has
+something to fail on.

--- a/tests/fixtures/dictation/src/content/notes/Main Branch.md
+++ b/tests/fixtures/dictation/src/content/notes/Main Branch.md
@@ -1,0 +1,7 @@
+---
+title: Main Branch
+visibility: public
+status: live
+---
+
+A two-word title that dictation sometimes runs together.

--- a/tests/fixtures/dictation/src/content/notes/Noontide.md
+++ b/tests/fixtures/dictation/src/content/notes/Noontide.md
@@ -1,0 +1,7 @@
+---
+title: Noontide
+visibility: public
+status: live
+---
+
+A one-word title that dictation reliably splits into two.

--- a/tests/helpers.mjs
+++ b/tests/helpers.mjs
@@ -17,6 +17,15 @@ export const run = promisify(execFile);
 /** A minimal project root: the directory containing `src/content`, never `src/content`. */
 export const VAULT = fileURLToPath(new URL('./fixtures/vault/', import.meta.url));
 
+/**
+ * Three notes whose only job is `graph related`'s name normalisation (#69).
+ *
+ * A separate root rather than three more notes in `VAULT`, because `VAULT`'s
+ * entry, edge and finding counts are asserted exactly in four suites, and a
+ * fixture added for one rule should not make every other suite's numbers move.
+ */
+export const DICTATION = fileURLToPath(new URL('./fixtures/dictation/', import.meta.url));
+
 export const BIN = fileURLToPath(new URL('../bin/commune.mjs', import.meta.url));
 
 /** Run the bin, never throwing: the exit code is part of what is under test. */

--- a/tests/related.test.mjs
+++ b/tests/related.test.mjs
@@ -10,7 +10,7 @@
 
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { BIN, commune, run, VAULT } from './helpers.mjs';
+import { BIN, commune, DICTATION, run, VAULT } from './helpers.mjs';
 
 test('a file source returns its links, its mentions and its inbound entries', async () => {
 	const { code, stdout } = await commune(
@@ -137,4 +137,64 @@ test('related runs on the engine with no Astro module on the path', async () => 
 	assert.equal(payload.source.urlPath, '/notes/atomic-notes/');
 	assert.ok(payload.summary.resolved > 0, 'expected resolved links');
 	assert.ok(payload.summary.inbound > 0, 'expected inbound entries');
+});
+
+test('a dictated title split across a space still finds the note', async () => {
+	const { code, stdout } = await commune(
+		'--root', DICTATION, 'graph', 'related', 'I talked about noon tide today.', '--json'
+	);
+
+	assert.equal(code, 0);
+	const { mentions } = JSON.parse(stdout);
+	assert.deepEqual(
+		mentions.map((mention) => [mention.title, mention.matched, mention.count]),
+		[['Noontide', 'noon tide', 1]]
+	);
+});
+
+test('a dictated title run together still finds the note', async () => {
+	const { stdout } = await commune(
+		'--root', DICTATION, 'graph', 'related', 'Merged it into mainbranch.', '--json'
+	);
+
+	// The title is "Main Branch"; `matched` reports the surface form, so the
+	// connect step can show which phrase in the dump the link would replace.
+	assert.deepEqual(
+		JSON.parse(stdout).mentions.map((mention) => [mention.title, mention.matched]),
+		[['Main Branch', 'mainbranch']]
+	);
+});
+
+test('normalising whitespace does not dissolve the word boundary at a title\'s edges', async () => {
+	const { stdout } = await commune(
+		'--root', DICTATION, 'graph', 'related', 'I ate a pancake.', '--json'
+	);
+
+	// "pancake" contains "cake" but is one word, so it is not a mention of Cake.
+	assert.deepEqual(JSON.parse(stdout).mentions, []);
+});
+
+test('a title inside a longer phrase is still a mention when the boundary is real', async () => {
+	const { stdout } = await commune(
+		'--root', DICTATION, 'graph', 'related', 'I ate a pan cake and some more cake.', '--json'
+	);
+
+	// "pan cake" normalises to "pancake", which contains "cake" at a real word
+	// boundary in the original — dictation splitting a word is exactly the case
+	// #69 exists for, and it cannot be told apart from a genuine two-word phrase.
+	assert.deepEqual(
+		JSON.parse(stdout).mentions.map((mention) => [mention.title, mention.matched, mention.count]),
+		[['Cake', 'cake', 2]]
+	);
+});
+
+test('a dictated draft on stdin finds both distorted titles at once', async () => {
+	const child = run(process.execPath, [BIN, '--root', DICTATION, 'graph', 'related', '-', '--json']);
+	child.child.stdin.end('---\ntitle: Draft\n---\n\nNoon Tide and Main Branch, dictated.\n');
+	const { stdout } = await child;
+
+	assert.deepEqual(
+		JSON.parse(stdout).mentions.map((mention) => [mention.title, mention.matched]),
+		[['Main Branch', 'main branch'], ['Noontide', 'noon tide']]
+	);
 });

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -1,0 +1,134 @@
+/**
+ * Tests for `commune render`.
+ *
+ * The claim this verb makes is that its HTML is the site's HTML, so the cases
+ * are the four link shapes whose rendering is decided by the engine's own
+ * plugins — a wikilink, a piped wikilink, one that resolves to nothing, and an
+ * external link — asserted as the exact anchors the built site emits. A shape
+ * check would pass on a pipeline missing a plugin, which is the failure this
+ * file exists to catch.
+ */
+
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { BIN, commune, run, VAULT } from './helpers.mjs';
+
+/** Render markdown from stdin, which is how a draft that is not a file is asked about. */
+async function render(markdown, ...args) {
+	const child = run(process.execPath, [BIN, '--root', VAULT, 'render', '-', ...args]);
+	child.child.stdin.end(markdown);
+	return child;
+}
+
+test('a wikilink renders as the anchor the site renders', async () => {
+	const { stdout } = await render('[[Alpha]] is a note.\n');
+
+	assert.equal(stdout.trim(), '<p><a href="/notes/alpha/" class="wikilink">Alpha</a> is a note.</p>');
+});
+
+test('a piped wikilink keeps the target and shows the label', async () => {
+	const { stdout } = await render('See [[Beta|the beta note]].\n');
+
+	assert.match(stdout, /<a href="\/notes\/beta\/" class="wikilink">the beta note<\/a>/);
+});
+
+test('a wikilink that resolves to nothing renders as plain text', async () => {
+	const { stdout } = await render('A [[Nonexistent Note]] here.\n');
+
+	// The site drops the brackets and renders the words. That is the behaviour
+	// worth pinning: it is why `--json` has to report `unresolved` separately,
+	// since by this point the broken link looks exactly like a sentence.
+	assert.equal(stdout.trim(), '<p>A Nonexistent Note here.</p>');
+});
+
+test('an external link is marked, an internal one is not', async () => {
+	const { stdout } = await render(
+		'[out](https://elsewhere.example/) and [home](https://wiki.example/x)\n',
+		'--site', 'https://wiki.example'
+	);
+
+	assert.match(
+		stdout,
+		/<a href="https:\/\/elsewhere\.example\/" target="_blank" rel="noopener noreferrer">out<\/a>/
+	);
+	assert.match(stdout, /<a href="https:\/\/wiki\.example\/x">home<\/a>/);
+});
+
+test('--json carries the html, the links and what resolved to nothing', async () => {
+	const { stdout } = await render('[[Alpha]], [[Beta|b]] and [[Nowhere]].\n', '--json');
+	const payload = JSON.parse(stdout);
+
+	assert.equal(payload.schema, 1);
+	assert.equal(payload.source.kind, 'stdin');
+	assert.match(payload.html, /href="\/notes\/alpha\/"/);
+	assert.deepEqual(
+		payload.links.map((link) => [link.target, link.resolved?.urlPath ?? null]),
+		[
+			['Alpha', '/notes/alpha/'],
+			['Beta', '/notes/beta/'],
+			['Nowhere', null],
+		]
+	);
+	assert.deepEqual(payload.unresolved, ['Nowhere']);
+});
+
+test('a path is read relative to the root, with its frontmatter split off', async () => {
+	const { code, stdout } = await commune(
+		'--root', VAULT, 'render', 'src/content/notes/Alpha.md', '--json'
+	);
+
+	assert.equal(code, 0);
+	const payload = JSON.parse(stdout);
+	assert.deepEqual(payload.source, { kind: 'file', file: 'src/content/notes/Alpha.md' });
+	// The title would be the first thing in the HTML if frontmatter were
+	// rendered as markdown, and `visibility: public` the second.
+	assert.equal(payload.html.includes('visibility'), false);
+	assert.match(payload.html, /<a href="\/notes\/beta\/" class="wikilink">the beta note<\/a>/);
+	assert.deepEqual(payload.unresolved, ['Nonexistent Note']);
+});
+
+test('the site comes from the Astro config when the flag does not name one', async () => {
+	// The engine's own config declares https://devonmeadows.com, so a link there
+	// is internal without anyone passing --site.
+	const child = run(process.execPath, [BIN, 'render', '-', '--json']);
+	child.child.stdin.end('[home](https://devonmeadows.com/notes/) and [out](https://example.org/)\n');
+	const { stdout, stderr } = await child;
+
+	const { html, site } = JSON.parse(stdout);
+	assert.equal(site, 'https://devonmeadows.com');
+	assert.equal(html.includes('href="https://devonmeadows.com/notes/" target'), false);
+	assert.match(html, /href="https:\/\/example\.org\/" target="_blank"/);
+	// Nothing to warn about: an origin was found.
+	assert.equal(stderr, '');
+});
+
+test('with no origin anywhere, the default is used and said out loud', async () => {
+	const { stdout, stderr } = await render('[out](https://elsewhere.example/)\n', '--json');
+
+	// The fixture vault has no astro.config, which is the case a draft rendered
+	// from a bare directory hits.
+	assert.equal(JSON.parse(stdout).site, 'https://example.com');
+	assert.match(stderr, /rendering against https:\/\/example\.com/);
+});
+
+test('a path that names no file is exit 1, not silently rendered as its own name', async () => {
+	const { code, stdout, stderr } = await commune('--root', VAULT, 'render', 'src/content/nope.md');
+
+	assert.equal(code, 1);
+	assert.equal(stdout, '');
+	assert.match(stderr, /cannot read src\/content\/nope\.md/);
+});
+
+test('render with no argument is a usage error naming both spellings', async () => {
+	const { code, stderr } = await commune('--root', VAULT, 'render');
+
+	assert.equal(code, 2);
+	assert.match(stderr, /render needs a path to a markdown file, or - for stdin/);
+});
+
+test('--site has to be an origin', async () => {
+	const { code, stderr } = await commune('--root', VAULT, 'render', '-', '--site', 'devon.md');
+
+	assert.equal(code, 2);
+	assert.match(stderr, /--site takes an origin/);
+});


### PR DESCRIPTION
Closes #69, #70, #60 — the three CLI prerequisites for the authoring skills (#10 plan, D6).

- `graph related`: titles and aliases match across whitespace and case inside a title, so "noon tide" finds `Noontide` and "main branch" finds `Main Branch`; whole-word at the edges, so "pancake" does not match `Cake`; `mentions[].matched` records the surface form.
- `graph query --unreferenced`: entries with no inbound links (any outbound), `updates` excluded unless asked; count in the summary.
- `commune render <path|->`: the site's own markdown pipeline on the CLI; HTML on stdout, `--json` gives `{ schema: 1, html, links, unresolved }`.

Verified by the orchestrator on devon-wiki read-only: the dictation probe returns `Main Branch, Noontide`; `--unreferenced` returns 0; `render` resolves `[[Cake]]`. 156 tests; build green; `backlinks.json` byte-identical; frozen lockfile OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1XXFXAsDP1ftHkaRbgwwz