### PR TITLE
fix: resolve wikilinks whose target title has an apostrophe

### DIFF
--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -348,6 +348,21 @@ export async function loadContentEntries(options: GraphOptions = {}): Promise<Co
  * matters when two pieces of content claim the same name, and is a content bug
  * either way.
  */
+/**
+ * The key a wikilink is looked up by. Case-folded, and typographic quotes
+ * folded to their ASCII forms: a title in frontmatter is written with a
+ * straight apostrophe, but by the time the remark plugin sees the link text
+ * smartypants has curled it, so `[[Andy's Notes]]` arrived as `Andy’s Notes`
+ * and rendered as plain text.
+ */
+export function linkKey(name: string): string {
+	return name
+		.trim()
+		.replace(/[\u2018\u2019\u02BC]/g, "'")
+		.replace(/[\u201C\u201D]/g, '"')
+		.toLowerCase();
+}
+
 export function buildLinkLookup(entries: ContentEntry[]): Map<string, LinkTarget> {
 	const lookup = new Map<string, LinkTarget>();
 
@@ -358,9 +373,9 @@ export function buildLinkLookup(entries: ContentEntry[]): Map<string, LinkTarget
 			urlPath: entry.urlPath,
 		};
 		for (const alias of entry.aliases) {
-			lookup.set(alias.toLowerCase(), target);
+			lookup.set(linkKey(alias), target);
 		}
-		lookup.set(entry.title.toLowerCase(), target);
+		lookup.set(linkKey(entry.title), target);
 	}
 
 	return lookup;

--- a/src/remark-wikilinks.ts
+++ b/src/remark-wikilinks.ts
@@ -12,7 +12,7 @@
 
 import { visit } from 'unist-util-visit';
 import type { Root } from 'mdast';
-import { getLinkLookup, type GraphOptions } from './lib/graph.ts';
+import { getLinkLookup, linkKey, type GraphOptions } from './lib/graph.ts';
 
 export type WikiLinksOptions = GraphOptions;
 
@@ -60,8 +60,7 @@ export default function remarkWikiLinks({ root }: WikiLinksOptions = {}) {
 
 			// Resolve WikiLink to URL path
 			const trimmedLinkText = linkText.trim();
-			const lookupKey = trimmedLinkText.toLowerCase();
-			const resolved = lookup.get(lookupKey);
+			const resolved = lookup.get(linkKey(trimmedLinkText));
 
 			if (resolved) {
 				// Create a proper link node with correct URL for collection

--- a/tests/fixtures/vault/src/content/notes/Beta.md
+++ b/tests/fixtures/vault/src/content/notes/Beta.md
@@ -4,6 +4,7 @@ visibility: public
 status: live
 aliases:
   - B
+  - Beta's twin
 tags:
   - seed
 ---

--- a/tests/render.test.mjs
+++ b/tests/render.test.mjs
@@ -26,6 +26,12 @@ test('a wikilink renders as the anchor the site renders', async () => {
 	assert.equal(stdout.trim(), '<p><a href="/notes/alpha/" class="wikilink">Alpha</a> is a note.</p>');
 });
 
+test('a wikilink whose target has an apostrophe still resolves after smartypants curls it', async () => {
+	const { stdout } = await render("[[Beta's twin]] is an alias.\n");
+
+	assert.equal(stdout.trim(), '<p><a href="/notes/beta/" class="wikilink">Beta’s twin</a> is an alias.</p>');
+});
+
 test('a piped wikilink keeps the target and shows the label', async () => {
 	const { stdout } = await render('See [[Beta|the beta note]].\n');
 


### PR DESCRIPTION
On devon.md the home note's `[[Andy Matuschak's Notes]]` rendered as plain text while `commune check` said it resolved. Astro applies smartypants before user remark plugins, so the wikilink plugin saw `Andy Matuschak’s Notes` with a curly apostrophe and missed the lookup, which was keyed on the straight one.

Lookup keys now go through one `linkKey` helper in the graph core that folds typographic quotes to ASCII and case-folds, used when the lookup is built and when the remark plugin reads it. The fixture vault's Beta note gains the alias `Beta's twin`, and `render.test.mjs` asserts `[[Beta's twin]]` renders as the anchor the site renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1XXFXAsDP1ftHkaRbgwwz