### PR TITLE
fix: let starred wikilinks wrap instead of forcing the whole link to one line

### DIFF
--- a/src/components/StarredLinksScript.astro
+++ b/src/components/StarredLinksScript.astro
@@ -34,15 +34,16 @@
         if (note?.isStarred) {
           // Check if star isn't already there
           if (!link.querySelector('.star-indicator-inline') && !link.nextElementSibling?.classList?.contains('star-indicator-inline')) {
-            // Create wrapper to prevent line break between link and star
+            // The star must not land on a line of its own, but the link itself
+            // has to wrap like any other run of text: a whole-link nowrap
+            // pushed long titles onto their own line on phones. A no-break
+            // space glues the star to the link's last word and nothing else.
             const wrapper = document.createElement('span');
-            wrapper.style.whiteSpace = 'nowrap';
-            wrapper.style.display = 'inline';
 
             // Create star as a separate clickable element (not part of the link)
             const star = document.createElement('span');
             star.className = 'star-indicator-inline';
-            star.textContent = ' ⭐';
+            star.textContent = '\u00A0⭐';
             star.setAttribute('aria-label', 'Top 5% most linked - click to learn more');
             star.setAttribute('role', 'button');
             star.setAttribute('tabindex', '0');
@@ -67,7 +68,7 @@
               }
             });
 
-            // Wrap the link in the nowrap container
+            // Keep the link and its star as one span
             link.parentNode.insertBefore(wrapper, link);
             wrapper.appendChild(link);
             wrapper.appendChild(star);


### PR DESCRIPTION
The star script wrapped every starred link in a `white-space: nowrap` span so the ⭐ could not land on a line of its own. That also stopped the link text from wrapping: on a phone, a long starred title such as "AI shapes voice dumps into atomic notes" jumped to its own line and left a gap at the end of the previous one.

The span stays (link and star remain one element) but the nowrap goes, and a no-break space between the link and the star keeps only those two together. The link wraps like any other run of text.

The same change lands on devon-wiki, which still carries its own copy of this component until #8 moves it into the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1XXFXAsDP1ftHkaRbgwwz