### PR TITLE
docs: land four research notes that stayed on their branches

### DIFF
--- a/docs/research/2026-09-01-file-dep-ts-consumption.md
+++ b/docs/research/2026-09-01-file-dep-ts-consumption.md
@@ -1,0 +1,109 @@
+# Research: consuming commune-wiki as raw source via `file:` dep
+
+- **Context:** [noontide-co/commune-wiki#5](https://github.com/noontide-co/commune-wiki/issues/5) (parent map: [#2](https://github.com/noontide-co/commune-wiki/issues/2))
+- **Date:** 2026-09-01
+- **Question:** Can an Astro 4 consumer (devon-wiki) load remark plugins, Astro integrations, and `.astro` components from a `file:`-linked local package as raw `.ts`/`.astro` source, or must commune-wiki ship a build step (tsup/tsc dist)?
+- **Method:** primary sources only — Astro/Vite/Node/pnpm/npm docs and source code (Astro 4.16.x, Vite 5.4.x). No live reproduction was run; every behavior claim below traces to a cited doc or code path.
+
+## Answer (TL;DR)
+
+**No build step required.** Ship raw source — with one carve-out: the entry points that are *executed by Node directly* (the remark plugin and integration factory imported by `astro.config.mjs`, and the CLI `bin` script) must be plain `.js`, because those paths bypass Vite's transform and Node refuses to run `.ts` from inside `node_modules`. Everything else — `.astro` components, and any TS imported from frontmatter/pages — is compiled by Astro's Vite pipeline straight from source, exactly as Astro's own publishing docs recommend. A tsup/tsc dist is unnecessary friction for the `file:` dogfood loop.
+
+---
+
+## (a) remark plugin + integration imported from `astro.config.mjs`
+
+How Astro 4 actually loads the config ([astro@4.16.18 `packages/astro/src/core/config/vite-load.ts`](https://github.com/withastro/astro/blob/astro%404.16.18/packages/astro/src/core/config/vite-load.ts)):
+
+1. For `.mjs`/`.js` config files it first tries a **native Node `import()`**.
+2. On any failure it falls back to a throwaway Vite dev server and loads the config through **`server.ssrLoadModule()`** — i.e. through Vite's SSR transform pipeline.
+
+So whether `import remarkWikiLinks from 'commune-wiki/remark-wikilinks'` works from `astro.config.mjs` hinges on Vite SSR **externalization** of that bare import:
+
+- Vite's default: *"all dependencies are externalized except for linked dependencies"* ([Vite SSR options — `ssr.external`](https://vite.dev/config/ssr-options)); the decision is made in [`ssrExternal.ts`](https://github.com/vitejs/vite/blob/v5.4.19/packages/vite/src/node/ssr/ssrExternal.ts) via realpath resolution (`preserveSymlinks: false` default). "Linked" = realpath resolves **outside** `node_modules`.
+- Non-externalized (linked) modules go through Vite's transform → raw `.ts` is compiled by esbuild → **works**.
+- Externalized modules are handed to Node at runtime → Node must load the file itself. Node's built-in type stripping **explicitly refuses TypeScript under a `node_modules` path**: *"To discourage package authors from publishing packages written in TypeScript, Node.js refuses to handle TypeScript files inside folders under a `node_modules` path"* ([Node.js TypeScript docs](https://nodejs.org/api/typescript.html)). On older Node (18/20, which Astro 4 supports) `.ts` fails with `ERR_UNKNOWN_FILE_EXTENSION` outright. Either way: **fails**.
+
+Which linking mode you get depends on the package manager (see (d)):
+
+| Install mechanism | Layout | Vite sees | Raw `.ts` in `astro.config.mjs` |
+|---|---|---|---|
+| npm `file:` (default, `install-links: false`) | symlink to source dir ([npm install docs](https://docs.npmjs.com/cli/v10/commands/npm-install)) | linked → not externalized | ✅ works |
+| pnpm `link:` | symlink | linked → not externalized | ✅ works |
+| **pnpm `file:`** | **hard-linked copy under `node_modules/.pnpm`** ([pnpm link docs](https://pnpm.io/cli/link): "`file:` … the linked package is hard-linked to your project `node_modules`") | realpath inside `node_modules` → **externalized** | ❌ **fails** |
+
+Since devon-wiki uses pnpm and the plan is a `file:` dep in `package.json`, the pnpm row is the one that matters: **raw `.ts` imported from `astro.config.mjs` breaks under pnpm `file:`.** There is no clean consumer-side workaround — `vite.ssr.noExternal` can't help because the fallback config server is created before the user config is known (its `ssr.external` list is hardcoded in `vite-load.ts`).
+
+**Fix, not a build step:** author the config-consumed entry points (`remark-wikilinks`, the backlinks integration factory) as plain `.js`/`.mjs` (JSDoc types optional). Node loads them natively regardless of externalization, and the Vite path also handles them. Alternatively a *tiny* tsup build of just these entry points would work, but plain JS is lower friction.
+
+**`vite.optimizeDeps`:** not involved here (pre-bundling is dev-mode, client-side only — [Vite dep pre-bundling](https://vite.dev/guide/dep-pre-bundling)). For client-side code, linked deps are treated as source and not pre-bundled (must be ESM; add to `optimizeDeps.include` only if the linked dep ships CJS); restart dev with `--force` to pick up changes. Non-linked deps (pnpm `file:` hard-link) *are* pre-bundled, and esbuild handles TS fine, so client-side TS works either way.
+
+## (b) `.astro` components from a linked package
+
+Supported, no build step. Astro's own package-publishing docs state: *"Notice that there was no `build` step for Astro packages. Any file type that Astro supports natively, such as `.astro`, `.ts`, `.jsx`, and `.css`, can be published directly without a build step"* — and show an `exports` map pointing straight at `.astro` files ([Astro — publishing components/integrations](https://docs.astro.build/en/reference/publish-to-npm/)).
+
+The one gotcha is SSR **externalization again**, for dev SSR and for the prerender build: an externalized `.astro` import would be handed to Node, which can't parse it. Astro solves this by auto-detecting "Astro packages" with vitefu's `crawlFrameworkPkgs` and adding them to `ssr.noExternal` ([astro@4.16.18 `packages/astro/src/core/create-vite.ts`](https://github.com/withastro/astro/blob/astro%404.16.18/packages/astro/src/core/create-vite.ts)):
+
+```js
+return (
+  pkgJson.peerDependencies?.astro ||
+  pkgJson.dependencies?.astro ||
+  pkgJson.keywords?.includes('astro') ||
+  pkgJson.keywords?.includes('astro-component') ||
+  /^(?:@[^/]+\/)?astro-/.test(pkgJson.name)
+);
+```
+
+**Implication for commune-wiki's package.json:** the auto-detection needs at least one signal. `commune-wiki` doesn't match the `astro-*` name pattern, so it must declare `"peerDependencies": { "astro": "^4" }` and/or keywords `astro-integration` / `astro-component`. Without a signal, the consumer must set `vite.ssr.noExternal: ['commune-wiki']` — workable but a footgun, and mandatory under pnpm `file:` (hard-linked realpath never reads as "linked"). Astro also sets `resolve.dedupe: ['astro']` (same file), which keeps a single Astro instance as long as `astro` is a peer dep rather than a bundled copy.
+
+Nested `.astro` imports inside the package are fine once noExternalized (Astro keeps `astro/components` noExternal for exactly this reason — see `ALWAYS_NOEXTERNAL` in `create-vite.ts`).
+
+## (c) CLI `bin` resolution from a linked package
+
+Resolution itself is not the problem: both managers wire a dep's `bin` entries into `node_modules/.bin` — npm via `bin-links` (default true, [npm install docs](https://docs.npmjs.com/cli/v10/commands/npm-install)); pnpm does the same for `file:` deps and additionally installs the linked package's own dependencies, unlike `pnpm link` which requires manual install ([pnpm link docs](https://pnpm.io/cli/link)).
+
+The constraint is the same as (a): the bin script is executed by Node directly (shebang → `node`), so it must be plain `.js`. A `.ts` bin sits under a `node_modules` realpath under pnpm `file:` → Node refuses it per the type-stripping rule. Even under npm `file:` (symlink → realpath outside `node_modules` → modern Node would strip types) it would only work on recent Node with erasable-syntax-only TS — fragile. Ship the bin as `.js`.
+
+## (d) pnpm strict `node_modules` vs npm/yarn flat
+
+- **Phantom deps:** pnpm's non-flat layout symlinks only *direct* dependencies into the root `node_modules` ([pnpm motivation](https://pnpm.io/motivation)). Any import in commune-wiki source that isn't declared in its own `package.json` will fail under pnpm while silently working under npm/yarn hoisting. Audit `dependencies` before dogfooding (e.g. `globby`, `gray-matter`, `unist-util-visit` are used by the current mechanism code and must move with it).
+- **Link mechanics:** npm `file:` = symlink to the source folder (with `install-links: false` default); pnpm `file:` = hard-linked copy inside the virtual store; pnpm `link:` = symlink. This decides Vite's linked-detection and therefore the (a) outcome. pnpm recommends `file:` over `link:` for local dev because it *"better resolves the peer dependencies from the project"* ([pnpm link docs](https://pnpm.io/cli/link)) — which is what we want for the `astro` peer.
+- **Update propagation:** both symlink and hard-link reflect source *content* edits; with pnpm `file:` hard-links, newly added/renamed files require a re-`pnpm install` to materialize in the virtual store.
+- **Vite caches:** after linked-dep changes, restart dev with `--force` if the dep was pre-bundled ([Vite dep pre-bundling](https://vite.dev/guide/dep-pre-bundling)).
+
+## (e) Recommended lowest-friction format
+
+**Raw source, no build step, with JS entry points.** Concretely, for commune-wiki as a single package with subpath exports (charting decision):
+
+```json
+{
+  "name": "commune-wiki",
+  "type": "module",
+  "peerDependencies": { "astro": "^4" },
+  "keywords": ["astro-integration", "astro-component", "withastro"],
+  "exports": {
+    "./remark-wikilinks": "./remark-wikilinks.js",
+    "./backlinks": "./astro.backlinks.js",
+    "./components/*": "./src/components/*.astro",
+    "./graph": "./src/graph.ts"
+  },
+  "bin": { "commune": "./bin/commune.js" }
+}
+```
+
+- `.js` for the three Node-executed surfaces (remark plugin, integration factory, bin). `.ts`/`.astro` raw everywhere else — Vite/Astro compile them in the consumer.
+- `peerDependencies.astro` + keywords do double duty: Astro's `ssr.noExternal` auto-detection (b) and correct peer resolution under pnpm `file:` (d).
+- If the package later gets config-consumed surfaces too complex for hand-maintained JS, a minimal tsup pass over *just those entry points* is the fallback — but it's not needed for the dogfood loop, and npm publish (deferred per map #2) doesn't require a dist either, since raw source publishes fine per Astro's docs.
+
+## Sources
+
+- [Astro — Publishing components/integrations to npm](https://docs.astro.build/en/reference/publish-to-npm/) ("no `build` step for Astro packages… `.astro`, `.ts`, `.jsx`, `.css` can be published directly")
+- [astro@4.16.18 — `packages/astro/src/core/config/vite-load.ts`](https://github.com/withastro/astro/blob/astro%404.16.18/packages/astro/src/core/config/vite-load.ts) (Node-import-first, Vite `ssrLoadModule` fallback)
+- [astro@4.16.18 — `packages/astro/src/core/create-vite.ts`](https://github.com/withastro/astro/blob/astro%404.16.18/packages/astro/src/core/create-vite.ts) (`crawlFrameworkPkgs` → `ssr.noExternal`; `resolve.dedupe: ['astro']`; `ALWAYS_NOEXTERNAL`)
+- [Vite — SSR options (`ssr.external`, `ssr.noExternal`)](https://vite.dev/config/ssr-options) ("all dependencies are externalized except for linked dependencies")
+- [Vite — Dep Pre-Bundling, Monorepos and Linked Dependencies](https://vite.dev/guide/dep-pre-bundling)
+- [vite@v5.4.19 — `packages/vite/src/node/ssr/ssrExternal.ts`](https://github.com/vitejs/vite/blob/v5.4.19/packages/vite/src/node/ssr/ssrExternal.ts) (externalization decision logic)
+- [Node.js — TypeScript support](https://nodejs.org/api/typescript.html) (type stripping default; refused under `node_modules`)
+- [pnpm — `pnpm link` vs `file:` protocol](https://pnpm.io/cli/link) (symlink vs hard-link; peer dep resolution; dep installation)
+- [pnpm — Motivation](https://pnpm.io/motivation) (non-flat `node_modules`, phantom-dep isolation)
+- [npm — `npm install`](https://docs.npmjs.com/cli/v10/commands/npm-install) (`file:` symlink semantics, `install-links`, `bin-links`)

--- a/docs/research/2026-09-02-obsidian-graph-access.md
+++ b/docs/research/2026-09-02-obsidian-graph-access.md
@@ -1,0 +1,326 @@
+# Research: does Obsidian expose a graph an external CLI can query?
+
+- **Context:** [dmthepm/commune-wiki#14](https://github.com/dmthepm/commune-wiki/issues/14) (parent map: [#2](https://github.com/dmthepm/commune-wiki/issues/2))
+- **Date:** 2026-09-02
+- **Question:** Commune plans to own a content graph. Obsidian already has one. Should commune own the graph outright, defer to Obsidian's, or own it and emit something Obsidian's tooling can consume?
+- **Method:** primary sources only — Obsidian's help docs, developer docs, changelog and official forum; the actual plugin and CLI source (GitHub, npm registry, package tarballs); plus direct inspection of a real Obsidian install on this machine (app 1.12.7, vault at `~/Documents/GitHub/devon`). Every behavioural claim below traces to a cited doc, a cited source file, or a command run locally and shown inline.
+
+## Answer (TL;DR)
+
+**Commune should own the graph outright, and emit plain `[[wikilinks]]` in the markdown so Obsidian keeps building its own from the same source of truth.** Not "defer", not "sync".
+
+The reason is a single hard fact that survived every avenue checked: **Obsidian's link graph exists only inside a running Obsidian process.** It is never written into the vault. It is persisted — but into the Electron app's Chromium IndexedDB store outside the vault, in a format that a) is LevelDB, which "may only be opened by one process at a time", so it is unreadable *while* Obsidian runs, and b) is Blink-serialised, so it is only parseable *when* Obsidian is closed by reimplementing a Chromium forensics reader.
+
+The thing that genuinely changed in 2026 is that Obsidian now ships an **official CLI** (1.12.0, 2026-02-10) with real graph verbs — `backlinks`, `links`, `orphans`, `deadends`, `unresolved`, `tags`, `base:query` — all with `format=json`. It is a good tool. It is also explicitly documented as requiring the desktop app: *"Obsidian CLI requires the Obsidian app to be running."* And **Obsidian Headless**, the standalone npm client that does not need the app, turns out to be Sync + Publish only — a file transport with no query surface at all.
+
+So the honest verdict on the ticket's central question: **there is no machine-readable graph an external Node CLI can query with the app closed.** Commune builds in CI (`astro build`); it cannot depend on a GUI app being alive. And commune is already doing the right thing — `remark-wikilinks.ts` and `astro.backlinks.ts` on `main` derive the graph from the markdown and emit `public/backlinks.json` and `public/graph.json`, with #3 consolidating them into `src/lib/graph.ts`. Keep that. The integration leg is one line of policy: **keep writing `[[wikilinks]]`**, and Obsidian rebuilds its own graph from commune's output for free.
+
+---
+
+## 1. Obsidian's link index: what it computes, and where it does not live
+
+### What it computes
+
+Obsidian's index is exposed to plugins as `MetadataCache`. Two fields carry the whole graph ([MetadataCache, developer docs](https://docs.obsidian.md/Reference/TypeScript+API/MetadataCache)):
+
+| Field | Type | Doc text (verbatim) |
+|---|---|---|
+| `resolvedLinks` | `Record<string, Record<string, number>>` | "Contains all resolved links. This object maps each source file's path to an object of destination file paths with the link count." |
+| `unresolvedLinks` | `Record<string, Record<string, number>>` | "Contains all unresolved links. This object maps each source file to an object of unknown destinations with count." |
+
+Note what this shape *is*: an adjacency map with edge weights, forward direction only. **Backlinks are not stored** — they are derived by inverting `resolvedLinks`. Per-file metadata comes from `getFileCache(file)` / `getCache(path)` returning [`CachedMetadata`](https://docs.obsidian.md/Reference/TypeScript+API/CachedMetadata): `links`, `embeds`, `tags`, `headings`, `sections`, `listItems`, `frontmatter`, `frontmatterLinks`, `frontmatterPosition`, `referenceLinks`, `footnotes`, `footnoteRefs`, `blocks` — all optional.
+
+Aliases are not a first-class cache field; they arrive through `frontmatter.aliases` and are applied during link resolution by `getFirstLinkpathDest(linkpath, sourcePath)`, documented only as "Get the best match for a linkpath" (since 0.12.5). That resolution rule — Obsidian's shortest-path-when-possible matching, alias handling, and ambiguity tie-breaking — **is not specified anywhere in the public docs**. [Internal links](https://obsidian.md/help/links) documents the syntax (`[[Note]]`, `[[Note#Heading]]`, `[[Note#^block]]`, `[[Note|Alias]]`, `![[embed]]`) and the *Settings → Files and links* toggles, but says nothing about how ambiguous names resolve. Anything that claims to mirror Obsidian's resolution is reverse-engineering it.
+
+The index is event-driven: `on('changed')`, `on('deleted')`, `on('resolve')` (one file resolved), `on('resolved')` (all files resolved). Those events only fire inside the app.
+
+### Where it is persisted — and why that does not help
+
+Obsidian's own help page is unusually direct ([How Obsidian stores data](https://obsidian.md/help/data-storage)):
+
+> "In order to provide a fast experience while using the app, Obsidian maintains a local record of metadata about the files in your vault called the metadata cache."
+
+> "IndexedDB is a low-level, client-side database that Obsidian uses for backend storage." — it "preserves the metadata cache when the application closes."
+
+And it names the app-data location: macOS `/Users/<user>/Library/Application Support/obsidian`, Windows `%APPDATA%\Obsidian\`, Linux `$XDG_CONFIG_HOME/obsidian/` or `~/.config/obsidian/`. The `.obsidian` folder *inside* the vault is described as holding "preferences specific to that vault, such as hotkeys, themes, and community plugins"; the only files it names are `workspace.json` and `workspaces.json`. No index.
+
+Verified locally against a real vault (`~/Documents/GitHub/devon/.obsidian`) — the entire contents:
+
+```
+app.json  appearance.json  core-plugins.json  workspace.json
+```
+
+Four settings files. **No link index, no graph data, no cache, in the vault at all.**
+
+The cache is instead here (verified on this machine, Obsidian 1.12.7):
+
+```
+~/Library/Application Support/obsidian/IndexedDB/app_obsidian.md_0.indexeddb.leveldb   # 64 MB
+```
+
+Grepping the `.ldb` segment files for cache field names confirms this is the metadata cache, and that the link index is in there:
+
+```
+3608  headings      845  frontmatter      341  listItems      32  embeds
+1157  linksA         99  graph             88  Links
+```
+
+Two properties make it useless as an external interface, and they are mutually exclusive in the worst way:
+
+1. **While Obsidian runs, you cannot read it.** The store is LevelDB and the directory contains a `LOCK` file. Per [LevelDB's own documentation](https://github.com/google/leveldb/blob/main/doc/index.md): *"A database may only be opened by one process at a time. The leveldb implementation acquires a lock from the operating system to prevent misuse."*
+2. **While Obsidian is closed, you can open it, but the values are Blink-serialised** Chromium IndexedDB records, not JSON. Reading them means running a Chromium IndexedDB forensics parser. There is no published format guarantee, and the path itself (`app_obsidian.md_0`) is keyed by the Electron *origin*, not by vault — one store holds every vault's cache.
+
+So the persistence is exactly backwards from what an external tool wants: locked when the data is fresh, opaque when it is readable, and undocumented in both states. Treating it as an API would be building on a Chromium implementation detail.
+
+**Version-dependent:** the `.obsidian` contents, the IndexedDB path, and the field names above are observed on Obsidian **1.12.7** (macOS, 2026-09-02). Current public release is **1.13.7** (2026-08-12, [changelog](https://obsidian.md/changelog/)). The *architecture* (cache in app-data IndexedDB, not the vault) has been stable for years and Obsidian documents it as such; the *specifics* are not contractual.
+
+---
+## 2. Dataview and Datacore
+
+### Dataview: real graph fields, one hop, in-app only
+
+Dataview exposes the graph through implicit `file.*` fields ([Metadata on Pages](https://blacksmithgu.github.io/obsidian-dataview/annotation/metadata-pages/)), quoted verbatim:
+
+| Field | Doc text |
+|---|---|
+| `file.inlinks` | "A list of all incoming links to this file, meaning all files that contain a link to this file." |
+| `file.outlinks` | "A list of all outgoing links from this file, meaning all links the file contains." |
+| `file.tags` | "A list of all unique tags in the note. Subtags are broken down by each level, so `#Tag/1/A` will be stored in the list as `[#Tag, #Tag/1, #Tag/1/A]`." |
+| `file.etags` | "A list of all explicit tags in the note; unlike `file.tags`, does not break subtags down" |
+| `file.aliases` | "A list of all aliases for the note as defined via the YAML frontmatter." |
+
+Link traversal in `FROM` has exactly four source types ([Sources](https://blacksmithgu.github.io/obsidian-dataview/reference/sources/)): tags, folders, specific files, and links — `[[note]]` for inbound, `outgoing([[note]])` for outbound.
+
+Two limits matter for the serendipity surface this ticket is scoping:
+
+- **Orphans are not a native concept.** Zero occurrences of "orphan" in the docs or `src/`. You write `LIST WHERE length(file.inlinks) = 0`.
+- **One hop only.** There is no transitive closure, no shortest path, no "within N hops", no recursive construct. `FROM [[x]]` and `outgoing([[x]])` do not compose into traversal. Multi-hop means hand-rolling a BFS in DataviewJS. Dataview answers *adjacency*, not *traversal*.
+
+Where its data comes from: both Obsidian's cache and its own inverted indices. `FullIndex` in [`src/data-index/index.ts`](https://github.com/blacksmithgu/obsidian-dataview/blob/master/src/data-index/index.ts) holds `metadataCache: MetadataCache` ("Access to in-memory metadata"), `links: IndexMap` ("Map files -> linked files in that file, and linked file -> files that link to it"), and `persister: LocalStorageCache` ("Persistent IndexedDB backing store, used for faster startup"). `file.inlinks` comes from Dataview's own inverse index ([`src/data-model/markdown.ts`](https://github.com/blacksmithgu/obsidian-dataview/blob/master/src/data-model/markdown.ts)); `FROM [[note]]` resolves via Obsidian's `resolvedLinks` ([`src/data-index/resolver.ts`](https://github.com/blacksmithgu/obsidian-dataview/blob/master/src/data-index/resolver.ts)).
+
+**Its persistence has the same problem as Obsidian's.** From [`src/data-import/persister.ts`](https://github.com/blacksmithgu/obsidian-dataview/blob/master/src/data-import/persister.ts):
+
+```js
+this.persister = localforage.createInstance({
+    name: "dataview/cache/" + appId,
+    driver: [localforage.INDEXEDDB],
+    description: "Cache metadata about files and sections in the dataview index.",
+});
+```
+
+Electron IndexedDB keyed by `app.appId` — **nothing in `.obsidian/plugins/dataview/` to parse.**
+
+**Headless: no.** The npm package [`obsidian-dataview`](https://www.npmjs.com/package/obsidian-dataview) (latest **0.5.68**, 2025-03-15) is typings plus the parser; `getAPI(app)` needs a live Obsidian `App`. Requiring `lib/index.js` in plain Node fails with `Cannot find module 'obsidian'`. With a stubbed `obsidian`, the *grammar* alone does work headlessly — `QUERY_LANGUAGE.query.tryParse('LIST FROM outgoing([[Foo]]) WHERE length(file.inlinks) = 0')` returns a correct AST — but the index and executor need `Vault`, `MetadataCache` and web workers. The maintainer's own position, [issue #92 "Generic library & CLI"](https://github.com/blacksmithgu/obsidian-dataview/issues/92), open since 2021-04-10: *"I like it; the direct way would be to just implement it as a TS/JS node package, and then build the CLI on top of that."* Five years later it is still open and unassigned.
+
+**Maintenance: effectively stalled.** Last stable **0.5.68** (2025-03-15); 0.5.69/0.5.70 are tagged but labelled "(Beta)" and live only in `manifest-beta.json`. Last commit to `master` was **2025-04-08**; the only newer branch activity is two unmerged dependabot branches. 662 open issues, 2026 PRs sitting unmerged. There is **no** explicit maintenance-mode or "superseded" statement from the maintainer — the README only calls Dataview "a hobby project" — so this is a de-facto reading of ~17 months of no merges, not a declaration.
+
+### Datacore: same architecture, same wall
+
+Datacore is real and in the community store — confirmed in [`community-plugins.json`](https://github.com/obsidianmd/obsidian-releases/blob/master/community-plugins.json): `{"id": "datacore", "author": "blacksmithgu", "description": "An even faster reactive query engine for the data obsessed."}`. Its [README](https://github.com/blacksmithgu/datacore) still self-describes as *"a **work-in-progress** re-imagining of Dataview"*, and the [docs](https://blacksmithgu.github.io/datacore/) place it "in a power-user stage focused on javascript/typescript savvy users". Latest release **0.1.29 (2026-03-23)**; last commit **2026-06-21**; open PRs as recent as 2026-08-16. Slow, not abandoned.
+
+It does not change the answer. [`src/index/persister.ts`](https://github.com/blacksmithgu/datacore/blob/master/src/index/persister.ts) is a near-verbatim copy of Dataview's: `localforage.createInstance({ name: "datacore/cache/" + appId, driver: [localforage.INDEXEDDB] })`. The npm library build `@blacksmithgu/datacore` is stale at **0.1.24 (2025-05-27)** against a 0.1.29 plugin, and is documented as typings. Maintainer on a CLI, [datacore#12](https://github.com/blacksmithgu/datacore/issues/12) (2023-09-15): *"It would be possible to make a daemon service that can be queried via a CLI or RPC… you would just need to mimic the file APIs that Obsidian provides… **I'm not currently looking at implementing this.**"*
+
+And the sharpest statement of the whole problem, from someone asking precisely commune's question ([datacore#168](https://github.com/blacksmithgu/datacore/issues/168), 2026-04-29): *"Datacore renders html inside obsidian that you can view when you open the note, but **is not persisting your tables or documents anywhere.** If you point your agent to those notes, they are going to see the datacore code, not the result of your queries."*
+
+That is the failure mode commune would inherit by deferring: an agent reading the vault sees query source, not query results.
+
+---
+## 3. Bases — changes one axis, not the decisive one
+
+Bases is now a **GA core plugin**, not a beta. It arrived in 1.9.0 early access (2025-05-21, [changelog](https://obsidian.md/changelog/2025-05-21-desktop-v1.9.0/)) and went public in 1.9.10 (2025-08-18, [changelog](https://obsidian.md/changelog/2025-08-18-desktop-v1.9.10/)). [Introduction to Bases](https://obsidian.md/help/bases): *"Bases is a core plugin that lets you create database-like views of your notes."*
+
+### It is a plain YAML file in the vault
+
+`.base` is a first-class [accepted file format](https://obsidian.md/help/file-formats) alongside `.md` and `.canvas`. Per [Bases syntax](https://obsidian.md/help/bases/syntax): *"When you create a base in Obsidian, it is saved as a `.base` file… Bases must be valid YAML conforming to the schema defined below."* Top-level keys: `filters`, `formulas`, `properties`, `summaries`, `views`. Notably: *"By default a base includes every file in the vault. There is no `from` or `source` like in SQL or Dataview."*
+
+The container is even typed in the public API — [`BasesConfigFile`](https://docs.obsidian.md/Reference/TypeScript+API/BasesConfigFile), *"Represents the serialized format of a Bases query as stored in a `.base` file."*
+
+### It does expose the graph — this is the part worth knowing
+
+The naive assumption ("Bases is frontmatter-only") is wrong. From the [file properties table](https://obsidian.md/help/bases/syntax):
+
+| Property | Doc text |
+|---|---|
+| `file.backlinks` | "List of backlink files. Note: This property is performance heavy. When possible, reverse the lookup and use `file.links`. Does not automatically refresh results when the vault is changed." |
+| `file.links` | "List of all internal links in the note, including frontmatter" |
+| `file.embeds` | "List of all embeds in the note" |
+| `file.tags` | "List of all tags in the file content and frontmatter" |
+
+Plus link functions ([Functions](https://obsidian.md/help/bases/functions)): `file.hasLink(otherFile)` — *"Returns true if `file` links to `otherFile`"* — and `link.linksTo(file)`. And the `this` context: *"When the base is in a sidebar, `this` refers to the active file… you can use `file.hasLink(this.file)` to replicate the backlinks pane."*
+
+`file.backlinks` shipped in 1.9.7 (2025-08-05, [changelog](https://obsidian.md/changelog/2025-08-05-desktop-v1.9.7/)).
+
+> **Doc discrepancy, worth flagging:** the [Functions](https://obsidian.md/help/bases/functions) page's File-type field table lists 11 fields and **omits `file.backlinks` and `file.embeds`**, while the syntax page lists 13 including both. The changelog confirms the syntax page is current. Do not use the Functions page as the property inventory.
+
+Limits: it is a per-row list-valued field, not a traversal engine. No multi-hop, no shortest path, no link position/context, no unresolved links. `file.backlinks` is documented as "performance heavy" and non-auto-refreshing (1.10.0 softened this to "View will periodically refresh the results of `file.backlinks`" — [changelog](https://obsidian.md/changelog/2025-10-01-desktop-v1.10.0/)).
+
+### But a `.base` is a query, not results
+
+Nothing is persisted. [Introduction to Bases](https://obsidian.md/help/bases): *"All the data in Obsidian Bases is stored in your local Markdown files and their properties."* The `.base` holds the query; `QueryController` is documented as *"Responsible for executing the Bases query and evaluating filters and formulas. Notifies views of updated results."* Live, push-based, in-process.
+
+And the expression language inside those YAML strings **has no published grammar, schema, or reference parser**. The Functions page punts on semantics: *"Bases functions follow JavaScript behavior. For complete reference documentation, refer to MDN Web Docs."* An external evaluator would have to reimplement the lexer/parser, the type system (string/number/boolean/date/duration/list/object/link/file/regex plus date arithmetic), ~100 built-ins with JS-conformant edge cases, Obsidian's wikilink resolution and link-equality rules, and its own backlink index — and would *still* fail on any base using plugin-registered functions or view types, which the docs explicitly allow.
+
+The Bases plugin API (1.10.0+: [`registerBasesView`](https://docs.obsidian.md/Reference/TypeScript+API/Plugin/registerBasesView), [`QueryController`](https://docs.obsidian.md/Reference/TypeScript+API/QueryController), [`BasesView`](https://docs.obsidian.md/Reference/TypeScript+API/BasesView), [`BasesQueryResult`](https://docs.obsidian.md/Reference/TypeScript+API/BasesQueryResult)) hangs entirely off `Plugin`/`App`. `QueryController` extends `Component` and exposes **no public execute method** — it cannot be driven standalone. It also took a breaking change in 1.12.
+
+**Verdict on Bases:** it moves the "what can Obsidian's query layer see" answer (it sees links), and it gives the CLI a clean `base:query … format=json`. It does not move the "app closed" answer at all.
+
+---
+
+## 4. CLI surfaces: what exists, what needs the app alive
+
+Obsidian shipped **two** first-party command-line surfaces in 2026. Any plan written on the assumption that no official CLI exists is out of date.
+
+| Surface | Official | App must be **running** | Returns data to stdout | Status |
+|---|---|---|---|---|
+| **Obsidian CLI** (`obsidian`) | ✅ bundled | ❌ **yes, required** | ✅ `format=json` | Shipped, stable |
+| **Obsidian Headless** (`ob`) | ✅ npm | ✅ no | ✅ `--json` | Open beta — **sync/publish only** |
+| `obsidian://` URI | ✅ | yes (launches it) | ✗ effectively no | Stable, legacy |
+| Advanced URI plugin | ✗ community | yes | ✗ clipboard only | Active (2.0.0, 2026-07-25) |
+| Local REST API plugin | ✗ community | yes | ✅ HTTP JSON + MCP | Active (5.1.0, 2026-08-01) |
+| notesmd-cli (ex-`obsidian-cli`) | ✗ community | ✅ no | ✅ | Active (v0.3.7, 2026-09-01) |
+| TurboVault | ✗ community | ✅ no | ✅ | Active (v1.6.0, 2026-07-18) |
+| obsidian-export | ✗ community | ✅ no | n/a (exporter) | Stale (v25.3.0, 2025-03-25) |
+| obsidian-metadata | ✗ community | ✅ no | ✅ | ⚠️ **archived** |
+
+### Obsidian CLI — the real graph, but the app must be alive
+
+Shipped in 1.12: early access 2026-02-10 ([changelog](https://obsidian.md/changelog/2026-02-10-desktop-v1.12.0/), *"Added a command line interface that lets you control Obsidian from your terminal for scripting, automation, and integration with external tools"*), public in 1.12.4 on 2026-02-27 ([changelog](https://obsidian.md/changelog/2026-02-27-desktop-v1.12.4/)). Enabled at Settings → General → Command line interface; needs the 1.12.7+ installer.
+
+It has a dedicated **Links** command group ([Obsidian CLI](https://obsidian.md/help/cli)), reading the real metadata cache rather than re-parsing:
+
+```
+backlinks   file=<name> path=<path> [counts] [total] format=json|tsv|csv   # "List backlinks to a file"
+links       file=<name> path=<path> [total]                               # "List outgoing links from a file"
+unresolved  [total] [counts] [verbose] format=json|tsv|csv                # "List unresolved links in vault"
+orphans     [total]                                                        # "List files with no incoming links"
+deadends    [total]                                                        # "List files with no outgoing links"
+tags        [file=|path=] [sort=count] [counts] format=json|tsv|csv
+base:query  file=<name> view=<name> format=json|csv|tsv|md|paths
+eval        code=<javascript>                                              # "Execute JavaScript and return result"
+```
+
+`eval` is the escape hatch: arbitrary JS in the app context, i.e. full `app.metadataCache.resolvedLinks`.
+
+Vault targeting is sane: *"If your terminal's current working directory is a vault folder, that vault is used by default… Use `vault=<name>` or `vault=<id>` to target a specific vault."*
+
+And then the constraint, stated twice on the page:
+
+> *"Obsidian CLI requires the Obsidian app to be running. If Obsidian is not running, the first command you run launches Obsidian."*
+> *"Obsidian must be running. The CLI connects to the running Obsidian instance."*
+
+This is remote control of a live GUI, not headless evaluation. In a CI runner or a `pnpm build`, it is unusable.
+
+### Obsidian Headless — no app needed, no graph either
+
+This looked like it might flip the answer. It does not. [Obsidian Headless](https://obsidian.md/help/headless): *"Obsidian Headless (open beta) is a headless client for Obsidian services… Obsidian CLI controls the Obsidian desktop app from your terminal. Obsidian Headless is a standalone client that runs independently, no desktop app required."*
+
+I pulled the published tarball to enumerate its actual surface. npm [`obsidian-headless`](https://www.npmjs.com/package/obsidian-headless), latest **0.0.14 (2026-07-30)**, first published 2026-02-27, maintainer `lishid` (Obsidian's lead developer), `engines: node >=22`, `bin: {ob: cli.js}`, **license `UNLICENSED`**. Its README opens: *"Headless client for Obsidian Sync and Obsidian Publish. Sync and publish your vaults from the command line without the desktop app."*
+
+The complete command list: `login`, `logout`, `sync-list-remote`, `sync-list-local`, `sync-create-remote`, `sync-setup`, `sync`, `sync-config`, `sync-status`, `sync-unlink`, `publish-list-sites`, `publish-create-site`, `publish-setup`, `publish`, `publish-config`, `publish-site-options`, `publish-unlink`.
+
+**Not one read, query, link, tag, or metadata command.** It is a file transport bound to paid Obsidian services. It gets a vault onto a machine without a GUI; it cannot answer a single graph question. (Corroborating: a [feature request asking for JSON output](https://forum.obsidian.md/t/obsidian-headless-should-have-json-ouput-like-obsidian-cli/113046) from 2026-04-05 is entirely about `sync-*` commands, with no staff reply.)
+
+This is the one thing that could plausibly flip the verdict later — if Headless ever grows query commands. It has not.
+
+### `obsidian://` and Advanced URI — write/navigate channels, not read APIs
+
+[Obsidian URI](https://obsidian.md/help/uri) documents `open`, `new`, `daily`, `unique`, `search`, `choose-vault`, `hook-get-address`. It is an OS protocol handler: invoking it hands the URI to the desktop app, launching or focusing it. The only return channel is `x-callback-url` — *"Obsidian will provide the following to the `x-success` callback: `name`… `url`… `file` (desktop only)"* — which dispatches **a second URI to another registered app**, not stdout and not an exit code. A shell script cannot read it without registering its own scheme handler, and the payload is file identity only, never content or links. `x-success` is documented on `new`, `daily`, `unique`, `hook-get-address` — **not on `open` or `search`**.
+
+[obsidian-advanced-uri](https://github.com/Vinzent03/obsidian-advanced-uri) (active: 2.0.0, 2026-07-25; last commit 2026-08-17; 1,201 stars) adds far more actions — heading/block/line navigation, writes, command invocation by ID, frontmatter edits, canvas focus. Its return channel is **the clipboard** (`exists=true` "Copies `1` to clipboard if file exists, `0` if not"). Racing the clipboard is not a data pipeline. Do not design extraction on either.
+
+### Local REST API — the only community surface that hands you Obsidian's own link data
+
+[coddingtonbear/obsidian-local-rest-api](https://github.com/coddingtonbear/obsidian-local-rest-api) is in good health: 5.1.0 (2026-08-01), last commit 2026-08-31, 2,879 stars, 3 open issues. It hosts an HTTPS server *inside* the Obsidian process (`https://127.0.0.1:27124`), so the app must be running — kill Obsidian and the port closes.
+
+Its `NoteJson` schema ([OpenAPI](https://coddingtonbear.github.io/obsidian-local-rest-api/openapi.yaml)) has required fields `backlinks` ("Vault-relative paths of files that link to this file"), `links`, `unresolvedLinks`, plus `tags` and `frontmatter` — Obsidian's own resolved cache, per file. There is no whole-graph endpoint, so a full graph means N requests. It also ships a built-in MCP server (18 tools).
+
+### Community CLIs: the category collapsed after 1.12
+
+- **`Yakitrak/obsidian-cli` no longer exists under that name** — it is now [Yakitrak/notesmd-cli](https://github.com/Yakitrak/notesmd-cli), and the README says why: *"With the release of the official Obsidian CLI, this project has been renamed from 'Obsidian CLI' to 'NotesMD CLI' to avoid confusion. NotesMD CLI works without requiring Obsidian to be running."* Very active (v0.3.7, 2026-09-01; 1,578 stars; 0 open issues). It reads the vault directory directly and has an explicit headless mode — but **no backlink or link-graph command**.
+- `gsrst/obsidian-cli`, `marcus-crane/obsidian-cli`, `jwhonce/obsidian-cli`: **all 404 on the GitHub API.** Dead or never existed; treat any reference as stale.
+- `Bip901/obsidian-cli` (Python): one day of activity in Sept 2025, ~1 year stale. Ignore.
+- Everything created since Feb 2026 under [topic:obsidian-cli](https://github.com/topics/obsidian-cli) **wraps the official binary** and inherits "app must be running": `kitschpatrol/obsidian-ts`, `MadnessOverflow/py-wrapper-for-obsidian-cli`, `pablo-mano/Obsidian-CLI-skill`, and others.
+
+### Vault re-parsers that genuinely work with the app closed
+
+These do not read Obsidian's index; they re-derive links and frontmatter from the markdown, so resolution can diverge from Obsidian's (aliases, shortest-path ambiguity, block refs).
+
+- [Epistates/turbovault](https://github.com/Epistates/turbovault) — Rust, active (v1.6.0 2026-07-18, last push 2026-08-28, 149 stars). The only actively maintained app-closed option with an explicit graph story: `turbovault-graph` ("Link graph analysis & relationship discovery"), `turbovault-parser`, `turbovault-sql`, plus an MCP server. Small, single-vendor — weigh the bus factor.
+- [zoni/obsidian-export](https://github.com/zoni/obsidian-export) — Rust, one-way CommonMark exporter. Last release v25.3.0 (2025-03-25); `main` last moved 2025-08-25, recent pushes are renovate noise. Its own README: *"obsidian-export is not officially endorsed by the Obsidian team. It supports most but not all of Obsidian's Markdown flavor."*
+- [natelandau/obsidian-metadata](https://github.com/natelandau/obsidian-metadata) — Python, **archived** (read-only). Do not build on it.
+- `danymat/Obsidian-Markdown-Parser` (2021), `tobiaswuerth/obsidian-tools` (archived), npm `obsidian-vault-parser` (0.4.1, 2022) — all dead.
+
+**No credible, current Node/TypeScript vault-graph parser exists.** The TS repos in this space all wrap the official CLI.
+
+---
+
+## 5. The honest verdict
+
+**Is there a machine-readable graph an external Node CLI can query with the Obsidian app closed? No.**
+
+Every path was checked and every one terminates at a running Obsidian process:
+
+| Path | App closed? | Why not |
+|---|---|---|
+| Read a vault file | — | Nothing in `.obsidian` holds the index; verified empirically |
+| Read Obsidian's IndexedDB | ✗ | LevelDB single-process lock while running; Blink-serialised and undocumented when closed |
+| Dataview / Datacore index | ✗ | Electron IndexedDB keyed by `appId`; npm packages are typings + parser, not engines |
+| Bases `.base` file | partial | The YAML query is readable; the expression language has no spec and no headless evaluator |
+| Obsidian CLI | ✗ | *"requires the Obsidian app to be running"* |
+| Obsidian Headless | ✅ runs | but ships **zero** query/graph commands — sync and publish only |
+| Local REST API | ✗ | plugin hosted inside the app process |
+| `obsidian://` / Advanced URI | ✗ | protocol handler; returns a URI or the clipboard, not data |
+| Third-party vault parsers | ✅ | but they re-parse markdown — that is *building your own graph*, not reading Obsidian's |
+
+Note the shape of the last row. The only app-closed options are tools that **re-derive the graph from the markdown**. That is precisely what commune already does. "Defer to Obsidian's graph" and "run with the app closed" are mutually exclusive, and the second is non-negotiable for a tool that builds in CI.
+
+---
+
+## 6. Recommendation
+
+### Chosen: **commune owns the graph outright, and emits Obsidian-consumable open formats**
+
+This is option three of the ticket's three, with the emphasis on *owns*. Concretely:
+
+1. **Keep the graph core as the single source of truth.** `main` already ships `remark-wikilinks.ts` + `astro.backlinks.ts` emitting `public/backlinks.json` (per-node `outbound`/`inbound`, aliases, collection) and `public/graph.json` (`outgoing`/`backlinks`/`unlinked`). Issue #3 is consolidating the duplicated scans into `src/lib/graph.ts`. That consolidation is the right move and this research does not disturb it.
+2. **Emit `[[wikilinks]]` in the markdown itself** — the one artifact Obsidian *does* consume natively and index for free. Obsidian's graph then rebuilds itself from commune's output with zero integration code. This is the "emit something Obsidian tooling can consume" leg, and it costs nothing because the notes are already written that way.
+3. **Treat the further open formats as optional surface, not as the graph.** Obsidian publishes three specs an agent can write directly: [Obsidian Flavored Markdown](https://obsidian.md/help/obsidian-flavored-markdown), [Bases `.base` YAML](https://obsidian.md/help/bases/syntax), and [JSON Canvas](https://jsoncanvas.org/spec/1.0/) ([obsidianmd/jsoncanvas](https://github.com/obsidianmd/jsoncanvas), MIT, 3.7k stars). Emitting a `.base` — say, an orphans view or a per-tag view — is cheap and makes commune's thinking legible inside Obsidian. Emitting a `.canvas` from a subgraph is a plausible serendipity surface. Neither is load-bearing.
+4. **Optionally consume the official CLI where the app is already open** — an interactive `commune` session on the user's desktop can shell out to `obsidian backlinks file=X format=json` to cross-check commune's resolution against Obsidian's. Useful as a *validation harness*, never as a build dependency.
+
+The strongest external signal for this split is Obsidian's own: [kepano/obsidian-skills](https://github.com/kepano/obsidian-skills) (47.7k stars, by Obsidian's CEO) — *"Agent skills for Obsidian. Teach your agent to use Obsidian CLI and open formats including Markdown, Bases, JSON Canvas."* It teaches agents to **write the open formats directly** and to use the CLI only for app-mediated work. That is the same line this recommendation draws.
+
+### Costs of each option
+
+**A. Commune owns the graph outright (chosen, with the emit leg).**
+
+- *Cost:* commune must reimplement Obsidian's link resolution — alias handling, shortest-path-when-possible matching, ambiguity tie-breaking, block and heading refs — and **that rule is not specified in any public doc**. Divergence between commune's resolution and Obsidian's is a permanent, low-grade risk. Mitigation is the validation harness in (4): diff commune's edges against `obsidian links`/`backlinks` output periodically, on a machine where the app runs.
+- *Cost:* commune carries its own indexing performance and correctness. It is already carrying this.
+- *Benefit:* works in CI, works with the app closed, works for users who do not run Obsidian at all, and works for the agent-skills use case where an agent reads the vault directly. No dependency on a proprietary GUI, a paid service, or an unspecified expression language.
+- *Benefit:* commune can compute things Obsidian cannot — multi-hop traversal, shared-tag proximity, weighted serendipity ranking. Neither Obsidian, Dataview, nor Bases does multi-hop.
+
+**B. Commune defers to Obsidian's graph.**
+
+- *Cost, fatal:* requires the Obsidian desktop app running for every graph read. `astro build` in CI dies. Any headless or server deployment dies. Any user without an Obsidian licence for the Catalyst-gated features, or on a platform where the CLI is not registered, dies.
+- *Cost:* the CLI is six months old and its Bases API already took a breaking change in 1.12. Coupling a build to it is coupling to a fast-moving surface.
+- *Cost:* Datacore issue #168 names the exact failure: an agent pointed at notes containing queries *"see the datacore code, not the result of your queries."* Deferring means commune's serendipity surface is invisible to anything that reads the files.
+- *Benefit:* resolution semantics are exactly right by construction, for free.
+
+**C. Commune owns it but keeps it in sync with Obsidian's.**
+
+- *Cost:* two indexes and a reconciliation loop, with no reliable trigger. Obsidian's `on('resolved')` event does not exist outside the app, and its cache is unreadable while the app is running — so "sync" means polling the CLI against a live GUI. Worst of both.
+- *Cost:* the checked-in `public/graph.json` on `main` already shows the drift hazard in miniature. It holds 5 nodes — `/VISION` and four `/decisions/ADR-*` — while `src/content/` ships 10 notes and one update, and none of the five. A committed build artifact has drifted completely off its source. That is a *single*-source artifact going stale; a dual-source reconciliation loop would be strictly worse. (Worth fixing independently: either regenerate it in `build` and gitignore it, or drop it.)
+- *Benefit:* none that A does not already provide more cheaply. The wikilink emit in A gives Obsidian everything it needs without a sync channel — because Obsidian re-derives its graph from the markdown anyway.
+
+---
+
+## Version-dependence
+
+Findings that are pinned to a version and could change:
+
+- **Observed on Obsidian 1.12.7** (this machine, macOS, 2026-09-02): `.obsidian` folder contents, IndexedDB path, cache field names. Current public release is **1.13.7** (2026-08-12).
+- **Obsidian CLI**: shipped 1.12.0 EA (2026-02-10), public 1.12.4 (2026-02-27); requires the 1.12.7+ installer. Six months old; command set may grow.
+- **Obsidian Headless**: `obsidian-headless@0.0.14` (2026-07-30), **open beta**, `UNLICENSED`, tied to paid Sync/Publish. **This is the finding most likely to change** — if Headless gains query commands, option B becomes viable for the first time. Recheck before any major graph rework.
+- **Bases**: GA since 1.9.10 (2025-08-18). `file.backlinks` added 1.9.7; refresh semantics changed in 1.10.0; plugin API 1.10.0+ took a breaking change in 1.12. Expression language still unspecified.
+- **Dataview**: last stable 0.5.68 (2025-03-15), last `master` commit 2025-04-08 — ~17 months idle. No maintenance-mode declaration exists; this is a de-facto reading.
+- **Datacore**: 0.1.29 (2026-03-23), last commit 2026-06-21, still self-described WIP. npm library build stale at 0.1.24.
+- **Obsidian's link resolution rule** is unspecified in public docs at every version checked. Assume it can change without notice.

--- a/docs/research/2026-09-02-obsidian-wikilink-resolution.md
+++ b/docs/research/2026-09-02-obsidian-wikilink-resolution.md
@@ -1,0 +1,305 @@
+# Research: how do `[[WikiLinks]]` resolve in Obsidian against slug-named files?
+
+- **Context:** [noontide-co/commune-wiki#15](https://github.com/noontide-co/commune-wiki/issues/15) (parent map: [#2](https://github.com/noontide-co/commune-wiki/issues/2))
+- **Date:** 2026-09-02
+- **Question:** Files are slug-named (`evergreen-notes.md`) with `title: Evergreen Notes` in frontmatter. The Astro remark plugin resolves `[[Evergreen Notes]]` by frontmatter **title**; Obsidian resolves by **filename**. Every cross-link works on the site and renders unresolved in the vault. What is the lowest-friction fix?
+- **Method:** primary sources only — the official Obsidian help sources, the official `obsidian-api` typings, and **the shipped Obsidian application bundle itself** (`obsidian-1.12.7.asar`, extracted and read). Where the bundle settles a question the docs leave open, the decompiled code path is quoted with its byte offset so it can be re-derived. One empirical check re-executes the shipped resolution algorithm, transcribed line-for-line, against a simulated vault. Repo facts come from reading `dmthepm/devon-wiki` and `noontide-co/commune-wiki` (read-only).
+
+## Answer (TL;DR)
+
+**The going-in hypothesis is wrong. `aliases` does not fix this.** Obsidian's vault-side link resolver consults *filenames only* — it never reads `aliases`. Adding `aliases: [Evergreen Notes]` to `evergreen-notes.md` will make the alias appear in autocomplete and the quick switcher, but `[[Evergreen Notes]]` still resolves to nothing: no click-through, no backlink, no graph edge, and it still counts as an unresolved link. Alias-based resolution *does* exist in the codebase — but only in the **Obsidian Publish** renderer, which is a different resolver in the same bundle. That is almost certainly the source of the folk belief that aliases resolve.
+
+**Recommendation: write link targets in filename form with the canonical title as piped display text — `[[evergreen-notes|Evergreen Notes]]`.** This is the only form both resolvers agree on today, it needs no renames and no URL churn, and it is indifferent to titles containing colons or running to 95 characters (both of which exist in the corpus and both of which block the rename route). The alias backfill is still worth doing — not for resolution, but because it makes Obsidian's own autocomplete *emit exactly this form for you*.
+
+Renaming files to their titles (`Evergreen Notes.md`) also works, and is genuinely attractive because it leaves all 433 existing links untouched — but it is blocked for 6 files whose titles contain `:` and produces 12 filenames of 70–95 characters, so it cannot be completed without editing user-visible titles. Details and the full cost comparison are in §5.
+
+---
+
+## Sources and how they were read
+
+| Source | What it settles |
+|---|---|
+| [Obsidian help — Aliases](https://help.obsidian.md/aliases) (source: [`obsidian-help/en/Linking notes and files/Aliases.md`](https://github.com/obsidianmd/obsidian-help/blob/master/en/Linking%20notes%20and%20files/Aliases.md)) | The `aliases` key, YAML shape, and the note that Obsidian deliberately writes `[[Target\|Alias]]` rather than `[[Alias]]` |
+| [Obsidian help — Internal links](https://help.obsidian.md/links) (source: [`Internal links.md`](https://github.com/obsidianmd/obsidian-help/blob/master/en/Linking%20notes%20and%20files/Internal%20links.md)) | Supported link formats, invalid filename characters, which settings are generation-time |
+| [Obsidian help — Properties](https://help.obsidian.md/properties) | Default property list and types; `alias` (singular) deprecated in 1.9+ |
+| [`obsidianmd/obsidian-api` — `obsidian.d.ts`](https://github.com/obsidianmd/obsidian-api/blob/master/obsidian.d.ts) | Public contract for `MetadataCache.getFirstLinkpathDest`, `resolvedLinks`, `unresolvedLinks` |
+| **`obsidian-1.12.7.asar` → `app.js`** (the shipped bundle, at `~/Library/Application Support/obsidian/`) | The actual resolution algorithm, and the exhaustive list of places `aliases` is read |
+| [Astro v4 — Content collections](https://docs.astro.build/en/guides/content-collections/) | Frontmatter `slug` override; `slug` is a reserved schema key |
+| `astro@4.16.19` → `dist/content/utils.js` (installed in both repos) | Confirms the frontmatter `slug` override is live in the pinned version |
+
+The help site now 301-redirects `help.obsidian.md/*` → `obsidian.md/help/*`; both resolve to the same content, and the `obsidian-help` GitHub repo is the authoritative Markdown source quoted below.
+
+---
+
+## 1. Alias resolution — it does not happen in the vault
+
+### 1a. The resolver reads filenames and nothing else
+
+`MetadataCache.getLinkpathDest` is the single entry point for turning a link target into a file. From `app.js` (offset 1578832), reformatted but otherwise verbatim:
+
+```js
+t.prototype.getLinkpathDest = function (e, t) {
+    if ("" === e && t && (f = this.vault.getAbstractFileByPath(t)) instanceof $T) return [f];
+    var n = e.toLowerCase(), i = nu(n), r = null;
+    if (i.contains(".") && (r = this.uniqueFileLookup.get(i)),
+        r || (i = nu(n = (e + ".md").toLowerCase()), r = this.uniqueFileLookup.get(i)),
+        !r) return [];
+    if (i === n && 1 === r.length) return r.slice();
+    /* ...remaining branches only disambiguate among the files already in `r`,
+       by comparing full paths and path suffixes. Nothing new is looked up. */
+}
+```
+
+Everything hangs off `this.uniqueFileLookup`. That map is populated at exactly three sites in the bundle, and every one of them keys on the **file's name**:
+
+```js
+this.uniqueFileLookup.add(s.name.toLowerCase(), s)   // initial vault load        (offset 1584692)
+this.uniqueFileLookup.add(e.name.toLowerCase(), e)   // computeFileMetadataAsync  (offset 1588561)
+r.remove(nu(t).toLowerCase(), e), r.add(e.name.toLowerCase(), e)  // onRename     (offset 1590599)
+```
+
+There is no fourth site, and `aliases` appears in none of them. `getFirstLinkpathDest` is just `getLinkpathDest(...)[0]`, and `isUnresolved` is `!this.getFirstLinkpathDest(...)` — so the whole resolution surface inherits this.
+
+### 1b. Which surfaces this poisons
+
+Everything that reports on links is computed from that one function:
+
+- **`resolvedLinks` / `unresolvedLinks`** are built by the link resolver (offset 1587300): `var a = t.getFirstLinkpathDest(o, e); if (a) n[a.path] = ...; else { var s = BL(o); i[s] = ... }`.
+- **Graph view** reads those two maps directly (offset 2553904, inside the graph renderer: `var r = e.resolvedLinks, o = e.unresolvedLinks`). No separate resolution pass.
+- **Backlinks — linked mentions** uses `getBacklinksForFile` (offset 1581908): `a = t.getFirstLinkpathDest(o, i); a && a === e && n.add(i, r)`.
+- **Unresolved-link count** is `unresolvedLinks`, same map.
+
+So a bare `[[Evergreen Notes]]` against `evergreen-notes.md` is unresolved in the editor, unresolved in the graph, absent from backlinks, and counted as a dangling link — with or without an `aliases` entry.
+
+### 1c. Where `aliases` *is* read
+
+The frontmatter alias parser is a single function, `nT` (offset 1325289). Grepping every call site in the bundle gives the exhaustive list of alias-aware surfaces:
+
+| Call site (offset) | Surface | Effect |
+|---|---|---|
+| `getLinkSuggestions` (1577723) | `[[` autocomplete | Pushes `{file, path, alias}`. **`path` is the file path; the alias is only a label.** |
+| `getDisplaySuggestions` (1650365) | autocomplete after the `\|` | Offers aliases as display text |
+| quick switcher (2813971, `shouldShowAlias`) | Ctrl/Cmd-O | Alias matches jump to the file |
+| backlinks pane (2869194) | **Unlinked** mentions only | Builds regexes from basename + aliases |
+| `3291378` | outgoing-links pane, unlinked mentions | same |
+| `1496288` | `aliases` developer-console command | listing only |
+| **`2208558`** | **Obsidian Publish cache** | **resolution — see below** |
+
+`getLinkpathDest`, `resolvedLinks`, `unresolvedLinks`, graph, and linked backlinks are absent from that list.
+
+### 1d. The Publish resolver — why the belief that aliases resolve is half-true
+
+At offset 2208258 there is a *second*, structurally similar resolver. It sits amid `publish.site`, `getPublicHref`, `publish.navigate`, and a `permalinks` map (`permalink` being a [Publish-only property](https://help.obsidian.md/properties)). It loads aliases into an index and falls back to them:
+
+```js
+// load():
+if (o = nT(r)) for (a = 0, s = o; a < s.length; a++) l = s[a], this.aliases[l.toLowerCase()] = n;
+
+// getLinkpathDest():
+var n = this._getLinkpathDest(e, t);        if (n.length > 0) return n[0];
+if ((n = this._getLinkpathDest(e + ".md", t)).length > 0) return n[0];
+var i = this.aliases, r = e.toLowerCase();  if (i.hasOwnProperty(r)) return i[r];
+var o = nu(e);                              return i.hasOwnProperty(o) ? i[o] : null;
+```
+
+**So `[[Evergreen Notes]]` *does* resolve via aliases on an Obsidian Publish site, and does not in the desktop vault.** Two different resolvers, one bundle. This is worth writing down, because it is exactly the kind of thing that produces confident, wrong advice in forum threads.
+
+The help docs corroborate the vault behaviour without stating it outright. From `Aliases.md`:
+
+> Obsidian creates the link with the alias as its custom display text, for example `[[Artificial Intelligence|AI]]`.
+>
+> > [!note] Note
+> > Rather than just using the alias as the link destination (`[[AI]]`), Obsidian uses the `[[Artificial Intelligence|AI]]` link format to ensure interoperability with other applications using the Wikilink format.
+
+Read alongside `getLinkSuggestions` — which stores the *file path* in `path` and the alias only as a label — the reason for the piped output is not merely interoperability: it is that the bare form would not resolve.
+
+### 1e. Exact key and accepted YAML shapes
+
+From the parser pair (offset 1325289):
+
+```js
+function tT(e, t) {
+    var n = eT(e, t);   // eT: first frontmatter key matching regex `t`
+    return n
+        ? "string" == typeof n ? [n.trim()]
+        : Array.isArray(n) ? n.filter(function (e) { return "string" == typeof e })
+                              .map(function (e) { return e.trim() })
+        : null
+        : null;
+}
+function nT(e) {
+    var t = tT(e, /^aliases$/i);
+    return t ? t.map(function (e) { return e.trim() })
+               .filter(function (e) { return !!e }) : null;
+}
+```
+
+| Shape | Result |
+|---|---|
+| `aliases:` / `Aliases:` / `ALIASES:` | all accepted — the key regex is `/^aliases$/i` |
+| `alias:` (singular) | **not matched.** Deprecated as a default property in Obsidian 1.9+ per [Properties](https://help.obsidian.md/properties); the bundle carries a one-way migration that renames `alias` → `aliases` (offset 3265839) |
+| YAML block list or inline `[A, B]` | accepted; non-string items silently dropped, each item trimmed, empties filtered |
+| a bare string `aliases: Evergreen Notes` | accepted as **one** alias |
+| a comma-separated string `aliases: A, B` | accepted as **one** alias literally named `"A, B"` — there is no comma split |
+| number, map, anything else | `null` — silently ignored |
+
+All comparisons are `toLowerCase()` on both sides, so alias matching (in the surfaces that use it) is case-insensitive. The docs say only: *"Aliases should always be formatted as a list in YAML."*
+
+### 1f. Empirical check
+
+The `getLinkpathDest` body above was transcribed line-for-line into Node and run against a simulated vault (`notes/evergreen-notes.md` carrying `aliases: ["Evergreen Notes"]`, plus a control file actually named `Evergreen Notes RENAMED.md`):
+
+```
+[[Evergreen Notes]]  (alias present, slug filename)  -> UNRESOLVED
+[[evergreen-notes]]  (exact filename)                -> notes/evergreen-notes.md
+[[Evergreen-Notes]]  (filename, wrong case)          -> notes/evergreen-notes.md
+[[EVERGREEN-NOTES]]  (filename, all caps)            -> notes/evergreen-notes.md
+[[notes/evergreen-notes]] (full path)                -> notes/evergreen-notes.md
+[[Andy Matuschak's Notes]] (alias w/ apostrophe)     -> UNRESOLVED
+[[Evergreen Notes RENAMED]] (filename == title)      -> notes/Evergreen Notes RENAMED.md
+```
+
+Two things fall out. The alias is inert. And **resolution is case-insensitive on the filename** — `[[Evergreen Notes]]` fails purely on the space-vs-hyphen difference, not on case. That matters for §5: link targets do not have to be typed in lowercase.
+
+---
+
+## 2. Settings — all three are generation-time, none are resolution-time
+
+Every one of the named settings is read only by link *authoring* code paths. None appears anywhere in `getLinkpathDest`.
+
+| Setting | Default (offset 1205167–1205770) | Only read by | Effect on resolution |
+|---|---|---|---|
+| **New link format** (`newLinkFormat`) | `"shortest"`; options `shortest` / `relative` / `absolute` | `fileToLinktext` (offset 1581908) | **none** — decides what text gets *written* into a new link |
+| **Use `[[Wikilinks]]`** (`useMarkdownLinks`) | `false` (i.e. wikilinks on) | `generateMarkdownLink` (1624651), link renderer (1647338) | **none** — decides whether a new link is written as `[[x]]` or `[x](x)`. Existing `[[...]]` links keep resolving either way |
+| **Default location for new notes** (`newFileLocation`) | `"root"` | `getMarkdownNewFileParent` (1611084), `getNewFileParent` (3181413) | **none** — where a *new file* is created |
+| **Automatically update internal links** (`alwaysUpdateLinks`) | `false` | rename handler (1615520) | **none** — rewrites links after a rename |
+
+The help docs describe both user-facing ones purely in generation terms: *"When you select one of the suggested files, Obsidian instead generates a Markdown link"*, and *"Obsidian can automatically update internal links in your vault when you rename a file."*
+
+**Conclusion: link resolution is not configurable.** There is no setting, on either the vault or the plugin-free app, that makes `[[Evergreen Notes]]` find `evergreen-notes.md`. The fix has to be in the content or in our own build.
+
+---
+
+## 3. What the repos actually do today
+
+Both repos pin `astro: ^4.15.0` (installed: **4.16.19**) and use legacy `type: 'content'` collections.
+
+**The Astro-side resolver keys on title and alias, never on slug.** In `devon-wiki/remark-wikilinks.ts` and in commune-wiki's extracted `src/lib/graph.ts` (`buildLinkLookup`), the lookup is built as:
+
+```ts
+lookup.set(alias.toLowerCase(), target);   // for each alias
+lookup.set(entry.title.toLowerCase(), target);
+```
+
+Lookup is case-insensitive; piped links are parsed (`/\[\[([^\]|]+)(?:\|([^\]]+))?\]\]/g`) and the pipe label is used as display text; unresolved links are emitted as **plain text with the brackets stripped** — silently non-clickable, no marker. `aliases` is already a first-class field in the zod schema (`aliases: z.array(z.string()).default([])`, commented *"Aliases for WikiLink resolution"*), the schema is not `.strict()`, and 49 of devon-wiki's 73 notes already carry the key. **Adding aliases breaks nothing.**
+
+Corpus shape (devon-wiki `src/content/notes/`): 73 notes, flat, all filenames strict slug-case, **433 wikilink occurrences across 79 distinct targets**. Filenames and titles diverge freely — `ledger-replaces-feeds.md` is titled *"See what I'm working on"*.
+
+**Three independent slug derivations, all filename-based, none reading frontmatter `slug`:** `remark-wikilinks.ts:pathToSlug`, `astro.backlinks.ts:pathToSlug`, and commune-wiki's `graph.ts:toUrlPath`. This is the hidden cost of the rename route (§5). commune-wiki has already collapsed its copy into one function; devon-wiki still has two.
+
+Neither repo contains an `.obsidian/` directory, so there are no vault settings in version control — the vault is configured elsewhere and syncs in.
+
+---
+
+## 4. Interaction with the canonical-title rule
+
+`devon-wiki/scripts/test-search-index.mjs` gates every build (`"build": "astro build && node scripts/test-search-index.mjs"`). commune-wiki has no equivalent; its build is plain `astro build`.
+
+It builds `canonicalTargets` from titles **and aliases**, mapping each key to the canonical *title*:
+
+```js
+canonicalTargets.set(entry.title.toLowerCase(), entry.title);
+for (const alias of entry.aliases || []) canonicalTargets.set(alias.toLowerCase(), entry.title);
+```
+
+then fails the build on:
+
+```js
+if (customLabel || linkedTitle !== canonicalTitle) { noncanonicalWikiLinks.push(...) }
+```
+
+Two consequences:
+
+1. **Adding an `aliases` key does not conflict with the rule.** It only widens `canonicalTargets`. Confirmed: zero piped links exist anywhere in devon-wiki's content today.
+2. **But the rule forbids ever *using* an alias in a link.** `linkedTitle !== canonicalTitle` is an exact, case-sensitive comparison, so `[[evergreen]]` and even `[[evergreen notes]]` fail the build. And `customLabel ||` bans piped links outright, including `[[Evergreen Notes|Evergreen Notes]]`.
+
+So the alias route does not *conflict* with the rule — it is rendered pointless by it. The rule is one day old ([`d6720ab` "[fix] Enforce canonical wiki link titles"](https://github.com/dmthepm/devon-wiki/commit/d6720ab), 2026-09-01), so it is a fresh, revisable decision rather than settled ground.
+
+One live hazard worth flagging regardless of which route is taken: **adding an alias can retroactively break the build.** A link that was previously unresolvable is skipped by `if (!canonicalTitle) continue;`; once an alias makes it resolvable it becomes a canonicality failure. Backfill aliases and re-run the build in the same commit.
+
+Note also that `README.md` (150–155) and `CONTRIBUTING.md` (265–270) both advertise `[[Note Title|Display Text]]` as supported syntax that the script forbids. The docs and the gate already contradict each other and need reconciling either way.
+
+---
+
+## 5. The two routes that actually work
+
+### Route A — filename-form targets, canonical title as display text (**recommended**)
+
+Write `[[evergreen-notes|Evergreen Notes]]`.
+
+- **Obsidian:** `evergreen-notes` → `+ ".md"` → exact hit in `uniqueFileLookup`. Resolves, clicks, appears in backlinks and the graph, drops off the unresolved count. Case-insensitive, so `[[Evergreen-Notes|…]]` works too.
+- **Astro:** needs the slug registered as a lookup key. In commune-wiki that is **one line** in `buildLinkLookup` (`lookup.set(entry.slug.toLowerCase(), target)`); devon-wiki would need it in `remark-wikilinks.ts` too, or an `aliases: [<slug>]` backfill (which several notes already have — `evergreen-notes.md` carries `aliases: ["evergreen", "evergreen-notes"]`).
+- **Display is identical in both** — the site renders the pipe label, and so does Obsidian's reading view.
+- **The alias backfill earns its keep here.** With `aliases: [Evergreen Notes]` on the file, typing `[[Evergreen` in Obsidian and selecting the alias inserts *exactly* `[[evergreen-notes|Evergreen Notes]]` — because `getLinkSuggestions` supplies the file path as the target and the alias as the label, and `newLinkFormat: "shortest"` reduces the path to the basename. The hypothesis was right about what to add and wrong about why: aliases are an **authoring ergonomic**, not a resolution mechanism.
+
+**Costs:** rewrite 433 link occurrences (mechanical, scriptable from `backlinks.json`, and verifiable — the existing `dist/notes/<slug>/index.html` href assertion in `test-search-index.mjs` proves every rewritten link still renders). Relax the canonicality rule from *"target must equal the canonical title, no pipes"* to *"target must be the canonical title **or** the entry's own slug, and the pipe label must be the canonical title"* — which preserves the rule's actual intent (no arbitrary relabelling) while permitting the one form both resolvers agree on. Update `README.md` and `CONTRIBUTING.md`.
+
+### Route B — rename files to titles, hold URLs with frontmatter `slug`
+
+Rename `evergreen-notes.md` → `Evergreen Notes.md` and add `slug: evergreen-notes`.
+
+The `slug` override is real and live in the pinned version. Astro v4 docs:
+
+> You can override an entry's generated slug by adding your own `slug` property to the file frontmatter.
+>
+> `"slug"` is a special, reserved property name that is not allowed in your custom collection `schema` and will not appear in your entry's `data` property.
+
+Confirmed in `astro@4.16.19/dist/content/utils.js:431` — `getEntrySlug` reads the frontmatter `slug` and hands it to `parseEntrySlug`, where it wins over the generated slug. Neither repo's schema declares `slug`, so the reserved-key constraint is already satisfied, and `src/pages/notes/[...slug].astro` routes on `note.slug`, so URLs would follow automatically.
+
+Its real appeal is that **all 433 links stay exactly as written**, the canonicality rule survives untouched, and `[[Evergreen Notes]]` — the form `docs/NOTE-WRITING-BIBLE.md` prescribes — resolves natively on both sides.
+
+**But it cannot be completed as-is:**
+
+- **Six titles contain `:`** (`Deep Research: OSS Business Models`, `The Commune Box: Hardware + Software Ecosystem Research`, and four more). The Obsidian docs list `:` among characters that *"may not work as a link"* and recommend against them; it is also illegal on Windows and rendered as `/` by Finder. These six cannot be renamed without editing a user-visible title.
+- **Twelve titles run 70–95 characters** — the claim-as-title evergreen style the note-writing bible actively encourages. Renaming produces 95-character filenames: legal on APFS, awkward everywhere else, and near Windows' 260-character path ceiling.
+- **Three slug-derivation sites must be patched** (`remark-wikilinks.ts`, `astro.backlinks.ts`, `graph.ts`) to prefer frontmatter `slug`. Miss any one and every wikilink on the site silently points at `/notes/Evergreen Notes/` while Astro serves `/notes/evergreen-notes/`.
+- **It couples filenames to a mutable editorial field.** Titles here are not stable identifiers; the corpus already demonstrates this.
+
+No case-insensitive title collisions exist today, so that risk is theoretical — but it becomes live the moment filenames are titles on a case-insensitive filesystem.
+
+### Rejected: an Obsidian community plugin that resolves by frontmatter title
+
+Technically possible (some plugins monkey-patch `metadataCache`), but it puts the requirement "click the cross links in Obsidian" behind a third-party runtime dependency, is unverifiable against primary sources, and does not travel with the repo. Out of scope for a content-and-build fix.
+
+### Comparison
+
+| | Route A (piped slug targets) | Route B (rename to titles) |
+|---|---|---|
+| Renames | 0 | 73 |
+| Frontmatter edits | 0 (or an optional alias backfill) | 73 × `slug:` |
+| Link occurrences rewritten | 433 | 0 |
+| Code sites touched | 1–2 | 3 |
+| Canonicality rule | must be relaxed | untouched |
+| Docs to update | README, CONTRIBUTING | none |
+| URL churn | none | none (via `slug:`) |
+| Blocked files | none | 6 (titles containing `:`) |
+| Blast radius | authored prose | filenames + frontmatter |
+| Survives long/punctuated titles | yes | no |
+
+Route B's blast radius is the safer kind — structure rather than prose — and if the corpus were all short, clean titles it would win. It is not. Six files it cannot touch at all and a house style that actively produces 90-character sentence-titles make it a migration that has to be *partially* abandoned at the point of contact, leaving the original bug in place for exactly the notes with the most distinctive titles. Route A is indifferent to title shape, which is the property that matters for a corpus written this way.
+
+---
+
+## Recommended sequence
+
+1. **commune-wiki first**, where the graph logic is already extracted to one place: add `lookup.set(entry.slug.toLowerCase(), target)` to `buildLinkLookup` in `src/lib/graph.ts`, below the alias pass and above the title pass so titles keep winning. Purely additive — every existing `[[Title]]` link keeps working.
+2. **Backfill `aliases: [<Title>]`** on notes whose title differs from their slug, and re-run the build in the same commit (see the retroactive-failure hazard in §4). This buys the Obsidian autocomplete that generates the correct link form.
+3. **Relax `test-search-index.mjs`** in devon-wiki: accept a target equal to the canonical title *or* the entry's own slug, and require any pipe label to equal the canonical title. Reconcile `README.md` and `CONTRIBUTING.md` with the new rule in the same change.
+4. **Rewrite the 433 links** to `[[slug|Canonical Title]]`, generated from `backlinks.json` rather than by hand-rolled regex over prose, and verify with the existing `dist/notes/<slug>/index.html` href assertions.
+5. Optionally add `slug:` frontmatter across the corpus regardless of route. It is inert today and it permanently decouples URLs from filenames, which makes any future rename — including a later change of heart toward Route B — free of URL churn.
+
+## Open questions
+
+- Steps 1–2 alone leave the 433 existing links unresolved in Obsidian while making every *newly authored* link work. If step 4 looks too invasive to land at once, that is a legitimate stopping point, but it should be a deliberate choice rather than a stall.
+- devon-wiki's `research` collection schema has no `aliases` field, and its four entries are the ones with colons in their titles. They need the field added if research notes are to be cross-linkable from the vault.
+- `status` is declared as `['draft','live','updated']` in the schema but defaults to `'seed'` in `astro.backlinks.ts` and `graph.ts`, and `README.md` documents `seed | growing | evergreen`. Unrelated to this ticket, but it will bite whoever touches the graph next.

--- a/docs/research/2026-09-02-positioning-and-adoption.md
+++ b/docs/research/2026-09-02-positioning-and-adoption.md
@@ -1,0 +1,624 @@
+# Research: compound engineering, and what makes agent-native tools spread
+
+- **Context:** [dmthepm/commune-wiki#16](https://github.com/dmthepm/commune-wiki/issues/16) (parent map: [#2](https://github.com/dmthepm/commune-wiki/issues/2))
+- **Date:** 2026-09-02
+- **Question:** What does compound engineering actually claim, what earned adoption for the reference set (`npx skills`, Matt Pocock's skills, Greptile CLI, morning-paper), what is commune's one-line claim, and what must commune get right at launch?
+- **Method:** primary sources — the Every essays and guide themselves, the GitHub and npm REST APIs (star/licence/date facts fetched 2026-09-02), the specs, and the skills actually installed on this machine under `~/.agents/skills/`. Where a claim is inference rather than something a source states, it is marked.
+- **Deliverable:** constraints, not a marketing plan. Every numbered constraint below is meant to be actionable against a ticket.
+
+---
+
+## TL;DR
+
+1. **Compound engineering's real mechanism is a filing convention, not an AI capability.** The transferable part is the fourth step — *compound* — where a session's residue is written back into durable files. Commune is already this shape; it should say so, and it should name the lineage explicitly rather than reinvent the vocabulary.
+2. **Positioning pick: "Own your canon. Anti-capture."** Reasoning and two alternates in §3.
+3. **The single highest-leverage launch constraint is `npx skills add dmthepm/commune-wiki` working on a cold machine**, followed by a `commune demo` that produces a real artifact offline. Everything else is downstream.
+4. **The licence should be MIT, not AGPL-3.0.** Every adopted reference in this space is MIT, including Devon's own two best-performing repos. This is flagged as a decision, not made unilaterally.
+5. **The current README is the biggest liability in the repo.** 423 lines, sixteen emoji-prefixed headings, a vendor-authored comparison table, and a `git clone` install. It reads as exactly the thing developers dismiss.
+
+---
+
+## 1. Compound engineering
+
+### 1.1 What it claims
+
+The term is Kieran Klaassen's, coined at Every in the essay **"My AI Had Already Fixed the Code Before I Saw It"** (Every, *Source Code*, 2025-08-18):
+
+> I call this **compounding engineering**: building self-improving development systems where each iteration makes the next one faster, safer, and better.
+
+— <https://every.to/source-code/my-ai-had-already-fixed-the-code-before-i-saw-it>
+
+The claim is positional against ordinary AI-assisted work, and the essay states the contrast directly:
+
+> Typical AI engineering is about short-term gains. You prompt, it codes, you ship. Then you start over. Compounding engineering is about building systems with memory, where every pull request teaches the system, every bug becomes a permanent lesson, and every code review updates the defaults. AI engineering makes you faster today. Compounding engineering makes you faster tomorrow, and each day after.
+
+The definitive statement is the co-authored **"Compound Engineering: How Every Codes With Agents"** by Dan Shipper and Kieran Klaassen (Every, *Chain of Thought*, 2025-12-11):
+
+> In traditional engineering, you expect each feature to make the next feature harder to build—more code means more edge cases, more interdependencies, and more issues that are hard to anticipate. By contrast, in compound engineering, you expect each feature to make the next feature *easier* to build. This is because compound engineering creates a learning loop for your agents and members of your team, so that each bug, failed test, or *a-ha* problem-solving insight gets documented and used by future agents.
+
+— <https://every.to/chain-of-thought/compound-engineering-how-every-codes-with-agents>
+(That URL now serves Every's evergreen guide content; the December 2025 essay body is preserved at the [Wayback snapshot of 2025-12-16](https://web.archive.org/web/20251216042234/https://every.to/chain-of-thought/compound-engineering-how-every-codes-with-agents), which is where these quotes are from.)
+
+The headline productivity claim, hedged in the original and usually repeated without the hedges:
+
+> Today, if your AI is used right, a single developer can do the work of five developers a few years ago, based on our experience at Every.
+
+The living guide (<https://every.to/guides/compound-engineering>, byline "Kieran Klaassen and Claude", last modified 2026-08-31) compresses it to one sentence:
+
+> The core philosophy of compound engineering is that each unit of engineering work should make subsequent units easier—not harder.
+
+### 1.2 The workflow in practice
+
+Four steps, as stated in December 2025: **Plan → Work → Review → Compound → Repeat.**
+
+> Plan: Agents read issues, research approaches, and synthesize information into detailed implementation plans. Work: Agents write code and create tests according to those plans. Review: The engineer reviews the output itself and the lessons learned from the output. Compound: The engineer feeds the results back into the system, where they make the next loop better by helping the whole system learn from successes and failures. This is where the magic happens.
+
+> Roughly 80 percent of compound engineering is in the plan and review parts, while 20 percent is in the work and compound.
+
+The guide is blunt that step four is the whole thing:
+
+> It's the fourth step that separates compound engineering from other engineering. This is where the gains accumulate. Skip it, and you've done traditional engineering with AI assistance.
+
+Klaassen expanded the loop to eight steps in **"Compound Engineering Gets an Upgrade"** (2026-05-29, <https://every.to/p/compound-engineering-gets-an-upgrade>):
+
+> So I expanded the loop: **Ideate → brainstorm → plan → work → review → polish → compound → repeat**. Ideate and brainstorm are the new front of the process. Polish is the new end. Compound is still the most important step, because the whole point is that every feature should make the next feature easier.
+
+And on where the human went:
+
+> the work phase has become boring—in the best way. If the plan is good and the agent has the right context, it usually does the work right. […] The question now is: "Where do I fit in?"
+
+**The artifacts.** This is the load-bearing detail, and the guide publishes the tree verbatim:
+
+```
+your-project/
+├── CLAUDE.md              # Agent instructions, preferences, and patterns
+├── docs/
+│   ├── brainstorms/       # /workflows:brainstorm output
+│   ├── solutions/         # /workflows:compound output (categorized)
+│   └── plans/             # /workflows:plan output
+└── todos/                 # /triage and review findings
+    ├── 001-ready-p1-fix-auth.md
+    └── 002-pending-p2-add-tests.md
+```
+
+> **docs/solutions/** builds your institutional knowledge because each solved problem becomes searchable documentation. Future sessions will find past solutions automatically.
+
+The compound step itself is four actions: *capture the solution*, *make it findable* ("Add YAML frontmatter to make sure it is tagged with the right metadata, tags, and categories for retrieval"), *update the system*, and *verify the learning* ("Would the system catch this automatically next time?").
+
+Two further stated beliefs matter for commune:
+
+> Plans are the new code. The plan document is now the most important thing you produce.
+
+> Make your environment agent-native. If a developer can see or do something, the agent should be allowed to see or do it too.
+
+The guide also revises the 80/20 split upward at the org level: *"you should allocate 50 percent of engineering time to building features, and 50 percent to improving the system."*
+
+### 1.3 The honest read
+
+The most credible independent assessment is Will Larson's (**"Learning from Every's Compound Engineering"**, 2026-01-19, <https://lethain.com/everyinc-compound-engineering/>). He is positive on the mechanism and deflationary about its durability:
+
+> an extremely effective way to convert these intuited best-practices into something specific, concrete, and largely automatic
+
+> If recent history is our guide, it's a solid guess that many of the practices in compound engineering will get absorbed into the Claude Code and Cursor harnesses over the next couple of months, at which point using these techniques explicitly will be indistinguishable from folks who are entirely unaware they're using them.
+
+The sharpest critique found (MoClaw, **"What Compound Engineering Actually Compounds"**, 2026-08-07, <https://moclaw.ai/blog/compound-engineering>) makes three points that apply directly to commune:
+
+> It compounds per repository, not per person. The artifacts live in `docs/`. Move to a different repo and you start from zero.
+
+> The 80/20 split is a recommendation, not a measurement.
+
+> The question is not whether the loop works. It is whether your engineers will read `docs/solutions/` in three months. That is a culture question.
+
+Klaassen has undercut his own system in public, which is worth knowing before leaning on the brand:
+
+> Opus 5 is out now! And it broke Compound Engineering, but I also like it. […] Just remember to let go of you skills and big mega prompts.
+> — <https://x.com/kieranklaassen/status/2080712817926443486>
+
+One more observation, my inference rather than a claim any source makes: despite ~24.8k stars on the plugin, compound engineering has **almost no adversarial Hacker News thread**. The canonical December 2025 essay scored 1 point and 0 comments (HN id 46237139); the guide got 2 points and 0 comments, twice. The discourse is nearly all Every-originated plus friendly derivative posts. Treat the idea as a well-marketed convention with a real mechanism inside it, not as a stress-tested consensus.
+
+### 1.4 What transfers to a personal wiki, and what does not
+
+**Transfers cleanly:**
+
+- **The compound step is commune's entire product.** Every's `docs/solutions/` — a solved problem, captured, frontmattered for retrieval, linked into a durable context file — is structurally identical to an evergreen note in a queryable graph. Commune's `dump → connect → grill → draft → refine → ship` is the same loop with the codebase swapped for a corpus. Commune should say this plainly; it is the strongest available credibility claim and it is true.
+- **"Make it findable" as a hard requirement, not a nicety.** Every's own guidance is that capture without retrieval metadata is wasted. This is the argument for the graph being queryable outside a build ([#18](https://github.com/dmthepm/commune-wiki/issues/18)) — a note that cannot be found by the next session did not compound.
+- **Plans are the artifact.** Commune's equivalent: the note, not the transcript. The dictation is disposable; the atomic note is the thing that must survive.
+- **Agent-native environment.** "If a developer can see or do something, the agent should be allowed to see or do it too" is the argument for the JSON-first CLI. Obsidian is a human surface; the CLI is the agent's equivalent, and they must see the same corpus.
+- **The 50/50 rule, adapted.** Half the time writing notes, half the time improving the note-writing system (the bible, the voice files, the skills). Commune already has `docs/NOTE-WRITING-BIBLE.md` as this artifact.
+
+**Does not transfer:**
+
+- **The compounding claim itself is weaker for a wiki.** In a codebase, "each feature makes the next easier" is measurable in shipped features. For a personal wiki there is no equivalent output metric, so the same rhetoric would be unfalsifiable. Do not borrow the "one person does the work of five" register. Commune's honest claim is *maintenance*, not *acceleration*.
+- **The per-repository critique lands harder here.** MoClaw's "move to a different repo and you start from zero" is a real weakness for CE; for commune it is a feature — there is exactly one corpus, and it is the user's. Say that. It is a genuine advantage over the thing being referenced.
+- **The parallel-review-agent apparatus does not port.** CE's fourteen named review agents and fifty-agent `/lfg` chain are a codebase-scale answer. A personal note does not need `security-sentinel`. Commune's `grill` is one adversary, not a swarm; scale here would be theatre.
+- **Larson's absorption warning applies double.** If the harnesses absorb memory and retrieval, the differentiated part of commune must be the corpus and the graph, not the prompt scaffolding. Build the graph; treat the skills as replaceable.
+
+### 1.5 The lineage is already in the stack
+
+`monologue-notes` from `EveryInc/monologue-toolkit` is installed on this machine (`~/.agents/.skill-lock.json` records `source: EveryInc/monologue-toolkit`, `skillPath: skills/monologue-notes/SKILL.md`). Monologue is Every's dictation product; the toolkit is the read API around it. Commune sits directly downstream: Monologue captures the voice, commune is what happens to it afterwards.
+
+Two facts about that repo are worth carrying:
+
+- **It is the design precedent for cross-harness skills.** SKILL.md line 15, verbatim: *"This skill is intentionally shell-first so it works across agents that can run terminal commands, including Codex and Claude Code."* The skill wraps a CLI rather than exposing an MCP server. This is the single most important architectural lesson in this brief — see C2.
+- **It is not a distribution precedent.** 62 stars, no repo description, no topics, and **no LICENSE file** (GitHub's licence field is `null`; `LICENSE` and `LICENSE.md` both 404). Source-available, not licensed for reuse. Every's own flagship, `EveryInc/compound-engineering-plugin`, is MIT with 24,763 stars. The difference between 62 and 24,763 in the same org is not quality; it is packaging.
+
+`EveryInc/compound-engineering-plugin` also demonstrates the multi-harness layout at scale: one directory per host — `.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`, `.devin-plugin/`, `.grok-plugin/`, `.opencode/`, `.cline/`, `.agents/` — plus `AGENTS.md`, `CLAUDE.md`, `GEMINI.md`, and governance files (`LICENSE`, `CONTRIBUTING.md`, `SECURITY.md`, `PRIVACY.md`, `CHANGELOG.md`). Its `CONCEPTS.md` is a repo glossary that self-describes as *"Shared domain vocabulary for this project… Seeded with core domain vocabulary, then accretes as ce-compound and ce-compound-refresh process learnings"* — the same artifact `domain-modeling` produces, and a good model for commune's `CONTEXT.md` ([#6](https://github.com/dmthepm/commune-wiki/issues/6)).
+
+---
+
+## 2. The reference set: what each did to earn adoption
+
+All star counts and licences fetched from the GitHub REST API on 2026-09-02.
+
+| Project | Stars | Licence | The move that earned it |
+|---|---:|---|---|
+| `mattpocock/skills` | 244,188 | MIT | Provenance + named enemies + failure-mode README |
+| `vercel-labs/skills` | 30,210 | MIT | Became the transport everyone else needs |
+| `EveryInc/compound-engineering-plugin` | 24,763 | MIT | One directory per harness; a named methodology |
+| `EveryInc/monologue-toolkit` | 62 | **none** | (counter-example: good design, no packaging) |
+| `noontide-co/mainbranch` | 37 | MIT | — |
+| `dmthepm/morning-paper` | 5 | MIT | (counter-example: see §2.4) |
+| `dmthepm/commune-wiki` | 1 | AGPL-3.0 | — |
+
+### 2.1 `vercel-labs/skills` — it became the rails
+
+Created 2026-01-14; 30,210 stars in under eight months. Repo description: *"The open agent skills tool - npx skills"*. The README's entire first screenful is four things — name, one sentence, the harness list, the install command:
+
+> # skills
+> The CLI for the open agent skills ecosystem.
+> Supports **OpenCode**, **Claude Code**, **Codex**, **Cursor**, and [73 more](#supported-agents).
+> ```bash
+> npx skills add vercel-labs/agent-skills
+> ```
+
+— <https://github.com/vercel-labs/skills>
+
+What it actually did to earn adoption was **solve someone else's distribution problem**. Before it, publishing a skill meant publishing N times, once per harness. `npx skills` made the unit of distribution a *git repo* rather than a package: `npx skills add owner/repo` works against GitHub shorthand, a full URL, GitLab, any git URL, or a direct `SKILL.md` download. It installs to `.agents/skills/` and symlinks into each harness's directory, with `-g` for global and `--copy` to opt out of symlinks. Verified on this machine: `~/.agents/.skill-lock.json` is `"version": 3`, records `skillFolderHash` per skill for update detection, and `~/.claude/skills/`, `~/.codex/skills/` and `~/.cursor/skills/` are all populated.
+
+**The lesson for commune is not "copy this." It is "ride it."** Commune does not need to solve cross-harness installation; that problem is solved, it is MIT, and Devon already has it installed. The map's decision to distribute via `npx skills add dmthepm/commune-wiki` is correct and this brief adds no caveat to it — only the requirement that the repo ship `skills/<name>/SKILL.md` at root so the resolver finds it.
+
+### 2.2 `mattpocock/skills` — provenance is the whole pitch
+
+244,188 stars, MIT. The repo description is the argument in eight words: *"Skills for Real Engineers. Straight from my .agents directory."*
+
+Three mechanisms, all copyable:
+
+**It names its rivals and says why they fail.**
+
+> Developing real applications is hard. Approaches like GSD, BMAD, and Spec-Kit try to help by owning the process. But while doing so, they take away your control and make bugs in the process hard to resolve.
+>
+> These skills are designed to be small, easy to adapt, and composable. They work with any model.
+
+**The README is organised by failure mode, not by feature.** The body is `#1: The Agent Didn't Do What I Want`, `#2: The Agent Is Way Too Verbose`, and so on — each opening with an epigraph from a canonical engineering text (*The Pragmatic Programmer*, Evans' *Domain-Driven Design*), then a stated **Problem**, then **The Fix** naming the skill. Failure mode #1 is resolved by `/grill-me` and `/grill-with-docs`, described as *"my most popular skills."* Failure mode #2 is resolved by a `CONTEXT.md` — and the proof offered is a before/after from a real repo of his own:
+
+> **BEFORE**: "There's a problem when a lesson inside a section of a course is made 'real' (i.e. given a spot in the file system)"
+> **AFTER**: "There's a problem with the materialization cascade"
+
+**Install is time-boxed in the heading and offers two paths with stated philosophies.** `## Installation (30-second setup)`:
+
+> Two ways in, two philosophies. **The Claude Code plugin** installs the whole set as a managed, read-only bundle that updates when I ship, so you subscribe rather than fork. **skills.sh** copies editable skill files into your project, so you can hack on them and make them your own. Pick one: installing both leaves you with every skill twice.
+
+Step 2 is `/setup-matt-pocock-skills`, run once per repo, which asks only three things (issue tracker, triage labels, docs location). Step 3 is literally "Bam - you're ready to go."
+
+He also publishes his ADRs in-repo and links them from the README (`.agents/adr/0002-ship-as-a-claude-code-plugin.md`), and his router skill `ask-matt` carries `disable-model-invocation: true` so it is reachable only by typing it.
+
+Commune's whole authoring loop — dump, connect, grill, draft, refine, ship — is already this family of skills; `grilling` and `wayfinder` from this repo are what produced the ticket this brief answers. The lineage is real and should be acknowledged rather than obscured.
+
+### 2.3 The Greptile CLI — a machine-first output contract
+
+Greptile's CLI is not open source, but it ships an **MIT-licensed skill** (`greptile-cli`, installed on this machine) that is the best available specimen of a CLI designed for agents rather than humans. Its frontmatter carries `license: MIT`, `metadata: {author: greptileai, minCliCompat: 3.3.0}`, and `allowed-tools: [Bash(greptile *), Bash(git *)]`.
+
+Four contract decisions worth stealing verbatim:
+
+> `greptile review` renders a live terminal UI by default. That output is not meant to be parsed. When running as an agent, always pass `--json` (structured) or `--agent` (plain text).
+
+> Agent environment variables (`CLAUDECODE`, `CLAUDE_CODE`, `CODEX_SHELL`, `CODEX_THREAD_ID`, `CODEX_CI`, `CURSOR_AGENT`) do **not** change the output format. They only suppress interactive surfaces like pickers and auto-login. Pass the flag.
+
+> A non-zero exit means the review did not finish. It does **not** mean findings were found. A review reporting ten `P0`s still exits `0`.
+
+> Do not install the CLI without asking.
+
+It also inverts the usual documentation default — *"Prefer this reference over running `greptile <cmd> --help`"* — and keeps the flag matrix and output schemas in `references/commands.md` and `references/output.md` rather than in `SKILL.md`.
+
+**This produces a correction to an accepted decision in the map.** [#2](https://github.com/dmthepm/commune-wiki/issues/2) records "meaningful exit codes (0 clean / 1 findings / 2 error)". Greptile explicitly rejects encoding findings in the exit code, and it is right: a command that exits non-zero because it found something is indistinguishable, to a shell, from a command that crashed. See C5.
+
+### 2.4 `dmthepm/morning-paper` — right about the demo, wrong about the door
+
+The positioning line lives in the **GitHub repo description**, not the README:
+
+> Own your algorithm. A print-first personal newspaper your agent composes from sources and preferences you own as files, rendered to PDF by a CLI. Anti-feed; runs on Claude Code and Codex.
+
+The README hero is a different, softer sentence — *"A real paper every morning, from your private newsroom."* That split is the first lesson: **the fighting line is hiding in a metadata field while the README opens with a mood.**
+
+What it gets right, and commune should copy exactly:
+
+- **The demo is the success criterion, and it is stated as a refusal to accept a weaker one.** The setup prompt says success is *"a real demo PDF on disk and open on my screen, not just a successful package install"*, ends with *"Stop when the demo PDF exists and is open on my screen"*, and defers everything else: *"Do not set up my private newsroom yet. First prove the engine prints."*
+- **The demo runs offline.** First bullet under "What It Does": *"Renders a demo paper with no config or network."*
+- **Negative-space claims.** *"No database. No Docker. No hosted account required. No fabricated filler: a missing source prints 'not configured' or 'nothing today.'"* Naming what it will not do is a costly signal; feature lists are not.
+- **It defers to the host's primitives instead of inventing its own.** On scheduling: *"Prefer the native recurring primitive of the agent host you already use. Morning Paper should not invent a second scheduling system unless you ask for a local fallback."*
+- **`ROLES.md`** — eight numbered roles, *"each role reads the shared edition folder, does one job, and leaves one markdown handoff"* — is the job-split precedent the map already cites.
+
+What it gets wrong, at 5 stars after five months, MIT and genuinely good:
+
+- **The front door is a 20-line prompt you paste into an agent.** The manual install underneath needs a pinned Python 3.13, a `[pretty]` extra, `uv tool install` with `pipx` fallback, and on macOS `brew install pango gdk-pixbuf`.
+- **The plugin path requires adding a custom marketplace** (`/plugin marketplace add dmthepm/morning-paper`). Compare Pocock: *"It's in Claude Code's official marketplace, so there's nothing to add first."* A private marketplace has an audience of people who already decided to install.
+- **No repo topics, no homepage.** Same hole as commune.
+
+The engine is not the problem. The door is.
+
+---
+
+## 3. Positioning
+
+### 3.1 The template, reverse-engineered
+
+morning-paper's description has four beats: **imperative ownership claim → concrete mechanism sentence → coined enemy → harness proof.** Beat three is load-bearing. Pocock's equivalent is naming GSD/BMAD/Spec-Kit; `npx skills`'s is "77 agents"; Greptile's is "before anything is pushed." A line without an enemy is a description, and descriptions do not spread.
+
+The enemy has to be chosen carefully, because §5 shows the reflex commune will actually meet: *"Doesn't Obsidian already do pretty much the same?"* and *"Obsidian but with AI integration baked in up front."* The line's job is to make that reflex wrong in one reading.
+
+### 3.2 Candidate A — "Own your canon. Anti-capture."
+
+> Own your canon. Dictate; job-split agent skills turn the dump into atomic, cross-linked markdown over a queryable graph you can browse in Obsidian and publish as a static site. Anti-capture; runs on Claude Code, Codex and Cursor.
+
+**Reasoning.** The enemy is *capture* — the thing every PKM tool sells and the thing that demonstrably fails its users. Westenberg deleted 10,000 notes and wrote *"I started reading to extract. Listening to summarize... I stopped wondering and started processing."* The top comment in that thread is *"I would never read them again."* Declaring against capture is a real positional claim against the entire category, and it is aimed at the tool's failure rather than the user's discipline.
+
+"Canon" carries the maintenance claim: a canon implies things were promoted, revised, and superseded. That is commune's actual differentiator against dictation-to-notes products — Granola, Mem, Reflect and Monologue itself all capture; none revise. It also answers the Obsidian reflex directly, because Obsidian is a *vault*, and a vault is storage.
+
+**Risk.** "Canon" needs half a beat to land and reads slightly literary. It is the least immediately concrete of the three.
+
+### 3.3 Candidate B — "Say it once. Anti-graveyard."
+
+> Say it once. A CLI and job-split agent skills turn dictation into a maintained markdown wiki — connected, grilled, drafted, shipped — browsable in Obsidian, published with Astro. Anti-graveyard; runs on Claude Code, Codex and Cursor.
+
+**Reasoning.** Highest recognition of the three: every developer has an abandoned vault, and "graveyard" names it in one word. "Say it once" is the dictation promise in three words and doubles as the atomicity rule.
+
+**Risk.** "Say it once" is a productivity-tool cliché and reads as an efficiency claim rather than a stance. "Graveyard" points the accusation at the user's past behaviour rather than at a competitor's product — self-deprecating where "anti-feed" was defiant. It also under-promises: the graveyard problem is solved by deleting notes, not by building a graph.
+
+### 3.4 Candidate C — "Your notes should argue back. Anti-slop."
+
+> Your notes should argue back. Dictate; skills connect the dump to what you already wrote, grill the claim, then draft an atomic note into a queryable markdown graph. Anti-slop; runs on Claude Code, Codex and Cursor.
+
+**Reasoning.** Leads on `grill`, the one step in the loop no competitor has, and converts the strongest objection to AI writing tools into the headline feature. "Slop" is Simon Willison's term for *"unwanted AI generated content"*, and §5 shows it is the single fastest way a project gets dismissed — claiming the opposite is a genuinely aggressive move.
+
+**Risk.** It is the highest-stakes line here: it must be earned in every note the tool emits, and one slop-shaped output falsifies it publicly. "Slop" is also trend-coupled and may date within a year. And it mis-scopes — commune does more than argue.
+
+### 3.5 Pick: **A — "Own your canon. Anti-capture."**
+
+Four reasons.
+
+1. **It attacks the category, not the user (B) or the medium (C).** "Anti-capture" says the incumbent tools are solving the wrong problem. That is a claim commune can defend on mechanism, because the graph and the revise step are real.
+2. **It survives its own roadmap.** If `grill` is renamed or Obsidian is dropped, A still holds; C dies with `grill`, and B is a promise about input rather than about the artifact.
+3. **It compounds Devon's other repos into one argument.** "Own your algorithm" (morning-paper) and "files-first" (mainbranch) plus "own your canon" reads as a body of work with a stance, not three unrelated side projects. That accumulation is itself an adoption asset.
+4. **It answers the Obsidian reflex.** Obsidian stores; commune decides. That distinction is the only defensible answer to *"how is this different from pointing an agent at a vault?"* — and it must be answerable in the first sentence, because §5 shows readers bail before the second.
+
+**Keep the losers as section headings, not taglines.** C's "your notes should argue back" is the right subhead for the `grill` section of the README. B's "say it once" is the right first line of the demo transcript.
+
+**One caveat, stated plainly:** a positioning line is a promise about the artifact. If the notes commune emits are not visibly better than what a bare agent pointed at a folder produces, no line in this section saves it. The line is downstream of C10.
+
+---
+
+## 4. What actually drives adoption
+
+Ordered by leverage. Where the evidence is weak, it says so.
+
+### 4.1 Install friction
+
+The peer group is not subtle. Claude Code leads with `curl -fsSL https://claude.ai/install.sh | bash` under a tab labelled "Native Install (Recommended)"; Codex, opencode and uv all lead with a piped shell script. Gemini CLI is the only true zero-install `npx` story — and it can be, because it is a JS package. **Commune is a Node CLI, so it gets the good option for free.**
+
+Claude Code's docs make the architectural point explicitly: *"The npm package installs the same native binary as the standalone installer... The installed `claude` binary does not itself invoke Node."* Install method and implementation language have decoupled. Commune does not need to care about this yet, but it means `npx` is a choice, not a constraint.
+
+**Honest gap:** no credible public source measures install-funnel drop-off for CLI tools. The claim "fewer steps means more installs" is universally assumed and nowhere instrumented. It is still the right bet, because every vendor with telemetry has made it.
+
+### 4.2 The first-run demo
+
+`clig.dev` is the primary source and is unambiguous on the zero-argument case:
+
+> **Display concise help text by default.** When `myapp` or `myapp subcommand` requires arguments to function, and is run with no arguments, display concise help text.
+
+> **Lead with examples.** Users tend to use examples over other forms of documentation, so show them first.
+
+Its best framing of first-run is as a conversation:
+
+> the user types a command, gets an error, changes the command, gets a different error, and so on, until it works. **This mode of learning through repeated failure is like a conversation the user is having with the program.** [...] At worst, it's a hostile conversation which makes them feel stupid and resentful.
+
+And on errors as documentation: *"Catch errors and rewrite them for humans... 'Can't write to file.txt. You might need to make it writable by running `chmod +w file.txt`.'"* Responsiveness budget: *"Print something to the user in <100ms."* 12 Factor CLI Apps converges independently and adds *"Never require a prompt though. The user needs to be able to automate your CLI in a script."*
+
+The sample-data precedent is Kibana's: *"Using sample data is a great way to start exploring the system and learn your way around... If you have no data, you will be prompted to install these packages when running Kibana for the first time."* Grafana's TestData, Superset's `load_examples`, Metabase's Sample Database and `streamlit hello` are the same pattern.
+
+**Honest gap:** no source instruments that zero-config reduces bounce. The mechanism is argued everywhere and measured nowhere.
+
+### 4.3 The README's opening seconds
+
+`standard-readme` requires a Short Description that *"Must be less than 120 characters"* and *"Must match GitHub's description."* The *Art of README* supplies the model:
+
+> A README is a module consumer's first -- and maybe only -- look into your creation.
+
+> The ordering presented here is lovingly referred to as "cognitive funneling"... the ordering of these key elements should be decided by **how quickly they let someone "short circuit" and bail on your module**.
+
+> your job, when you're doing it with optimal altruism in mind, isn't to "sell" people on your work. It's to let them evaluate what your creation does as objectively as possible.
+
+On badges, which applies equally to emoji: *"Be judicious in your use of badges... They add visual noise to your README... For each badge, consider: 'what real value is this badge providing to the typical viewer of this README?'"*
+
+GitHub's own guidance is thin but normative: *"A README should only contain information necessary for developers to get started using and contributing to your project. Longer documentation is best suited for wikis."* Commune's README is 423 lines.
+
+### 4.4 Screenshots and terminal recordings
+
+Charm's is the best first-party statement, written by a team reflecting on 100k stars:
+
+> The README is critically important to the success of an open source product. It's often a developer's first point of contact with a project and the place where a developer will, **in a matter of seconds**, judge whether the project worthy of further consideration.
+
+> Our strategy is to simply follow the age-old rule of advertising: showing the product.
+
+> GIFs... are the most effective medium we've encountered for illustrating how software works in a concise manner.
+
+— <https://charm.land/blog/100k/>
+
+**Tooling recommendation: VHS over asciinema, for a specific reason.** VHS (*"Write terminal GIFs as code"*) drives recordings from a plain-text `.tape` script, so the demo is diffable, reviewable and regenerable in CI — it cannot silently drift from the CLI it documents. asciinema's `.cast` files are also text and its selling point is real (*"just pause the player and copy-paste the content you want. It's just text after all!"*), but **asciinema does not render inline on GitHub**; it needs `agg` or `svg-term` to become an embeddable artifact. The *Art of README* adds a durability argument for inlining: *"your version control repository and its embedded README will outlive your repository host and any of the things you hyperlink to -- especially images."*
+
+**Honest gap:** there is no controlled study showing a hero GIF causes adoption. The only quantitative source (arXiv:2206.10772, n=1950) is correlational — popular READMEs use lists and images. Treat the GIF as what successful projects deliberately do, not as a proven lever.
+
+### 4.5 Cross-harness support — and a correction
+
+The governance picture settled in December 2025. The Linux Foundation formed the **Agentic AI Foundation** on 2025-12-09, anchored by MCP (Anthropic), goose (Block) and AGENTS.md (OpenAI), with AWS, Anthropic, Block, Bloomberg, Cloudflare, Google, Microsoft and OpenAI as platinum members. Anthropic published **Agent Skills** as an open standard at `agentskills.io` on 2025-12-18, spec repo MIT.
+
+The spec allows exactly six frontmatter fields — `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools` — and Claude Code enforces this at the packaging boundary with a hard error listing the allowed properties. `name` must match the parent directory. Progressive disclosure is budgeted: *"Metadata (~100 tokens)... Instructions (< 5000 tokens recommended)... Resources (as needed)"*, and *"Keep your main `SKILL.md` under 500 lines."*
+
+**Where each harness looks:**
+
+| Tool | Instruction file | Skills directories |
+|---|---|---|
+| Claude Code | `CLAUDE.md` **only** | `~/.claude/skills/`, `.claude/skills/` |
+| Codex | `AGENTS.md` | `.agents/skills`, `$HOME/.agents/skills` |
+| Cursor | `.cursor/rules/*.mdc` + `AGENTS.md` | `.agents/skills/`, `.cursor/skills/`, plus `.claude/skills/` compat |
+| VS Code / Copilot | `.github/copilot-instructions.md` | `.github/skills/`, `.claude/skills/`, `.agents/skills/` |
+
+Claude Code is the odd one out on both axes, and says so:
+
+> **Claude Code reads `CLAUDE.md`, not `AGENTS.md`.** If your repository already uses `AGENTS.md` for other coding agents, create a `CLAUDE.md` that imports it so both tools read the same instructions without duplicating them.
+
+`.agents/skills/` is the converging convention, and the spec's own implementation guide says why:
+
+> The `.agents/skills/` paths have emerged as a widely-adopted convention for cross-client skill sharing... scanning `.agents/skills/` means skills installed by other compliant clients are automatically visible to yours, and vice versa.
+
+**The correction — and this is the most surprising finding in this brief.** Two independent sources say context files and skills do not help by default.
+
+An ETH Zurich / LogicStar study (Gloaguen et al., arXiv:2602.11988, Feb 2026):
+
+> **Surprisingly, we find that providing context files does not generally improve task success rates, while increasing inference cost by over 20% on average.** [...] we find that while instructions in the context files are well followed by coding agents, **repository overviews, although popular and recommended by model providers, are not helpful.**
+
+And Vercel's own eval (2026-01-27), testing Next.js 16 APIs absent from training data:
+
+| Config | Pass rate |
+|---|---|
+| Baseline, no docs | 53% |
+| Skills, default | 53% |
+| Skills, explicit instructions | 79% |
+| `AGENTS.md` compressed docs index | **100%** |
+
+> **In 56% of eval cases, the skill was never invoked.** The agent had access to the documentation but didn't use it.
+
+The synthesis across both: **instructions get followed; repository overviews are dead weight; a skill only fires if its `description` is written as a trigger.** This turns the `description` field from metadata into the most important line in the file, and it makes an `AGENTS.md` that inlines the essential contract a *higher*-performing artifact than a skill that describes it. See C3 and C4.
+
+### 4.6 Licence
+
+The evidence here is one-sided enough to be worth stating bluntly, while leaving the decision with Devon.
+
+**Google's policy bans AGPL from workstations, not just from products** (<https://opensource.google/documentation/reference/using/agpl-policy>):
+
+> **WARNING: Code licensed under the GNU Affero General Public License (AGPL) MUST NOT be used at Google.**
+
+> - **Do not install AGPL-licensed programs on your workstation, Google-issued laptop, or Google-issued phone** without explicit authorization from the Open Source Programs Office.
+
+That second bullet is dispositive for a developer CLI: it bans *installing*, independent of any linking or distribution question. Developer discourse corroborates the pattern beyond Google — *"bigco policy is to not allow ANY AGPL code within a 10 mile radius of any computer owned by said company. The author(s) are free to use AGPL, but there are significant downsides if they care about adoption."*
+
+**The peer norms, both readings:**
+
+- As *agent tooling*: Apache-2.0 dominates (Codex, Gemini CLI, goose, aider). The most-starred agent CLI of all — opencode, 203,100 stars — is MIT. **Zero agent CLIs are AGPL.**
+- As *note/wiki tooling*: MIT is near-universal (Quartz, Astro, Docusaurus, Foam, the Obsidian API; a 200-plugin sample of the Obsidian ecosystem is ~80.5% MIT, 1% AGPL). AGPL appears only on end-user desktop *apps* — Logseq — never on libraries meant to be embedded.
+
+**Apache-2.0 is the serious alternative to MIT**, for its §3 patent grant and termination clause; the FSF recommends it over MIT on exactly those grounds (*"For substantial programs it is better to use the Apache 2.0 license since it blocks patent treachery"*), and Google mandates it internally. Its cost for a CLI is §4 notice compliance — Google's own guidance suggests a `--notices` flag. Apache-2.0 is also GPLv2-incompatible where MIT is compatible with everything.
+
+Commune is currently AGPL-3.0, which GitHub renders as licence "Other". Devon's own two best-performing repos, morning-paper and mainbranch (37 stars), are both MIT. Commune's AGPL is protecting a static-site generator against a hosted competitor that does not exist, at the cost of every developer whose employer has a licence policy.
+
+One structural note if a change is ever contemplated later: **every project that successfully relicensed — Grafana, Redis, MongoDB, Elastic — had a CLA.** DCO-only projects effectively cannot relicense without unanimous contributor consent. That is a feature if the goal is a credible no-rug-pull commitment, and a trap if it is not.
+
+---
+
+## 5. Anti-patterns: what gets a project like this dismissed
+
+Five kill-shots, each evidenced by developers reacting to real repos.
+
+### 5.1 The AI-slop README — the fastest kill
+
+> **The AI slop readme is a real turn off. Makes me question the quality/accuracy of the rest of the project.**
+> — <https://news.ycombinator.com/item?id=49225171>
+
+> Didn't make it past the first paragraph of AI slop in the README. **Have some respect for your readers and put actual information in it**, ideally human generated. At least the first paragraph! Otherwise you may as well name it IGNOREME.
+> — <https://news.ycombinator.com/item?id=47281562>
+
+> The readme is AI slop, and incredibly grating to read. **The disgust I felt while reading it almost put me off trying the project.** Is the code also AI slop?
+> — <https://news.ycombinator.com/item?id=48531868>
+
+The reaction is not unanimous — *"It's really demeaning to call someone's hard work 'AI slop'. Did you actually read the code?"* — but the asymmetry is what matters: **being wrongly accused costs the reader anyway.**
+
+The escape hatch is Simon Willison's, who coined the term (*"slop is the term for unwanted AI generated content"*, <https://simonwillison.net/2024/May/8/slop/>). His distinguishing variable is not AI-vs-human:
+
+> **I attach my name and stake my credibility on the things that I publish.**
+
+Reviewed and signed is not slop. Unreviewed and thrust upon someone is.
+
+### 5.2 Emoji headings are a named, specific tell
+
+> the emojis in the readme scream AI generated more than any emdash ever could.
+> — <https://news.ycombinator.com/item?id=45312970>
+
+> The AI generated emoji soup readme isn't exactly inspiring…
+> — <https://news.ycombinator.com/item?id=47289023>
+
+> The readme has crazy emojis & the code was all checked in at once, which is usually my telltale for these kinds of things.
+> — <https://news.ycombinator.com/item?id=46522706>
+
+Pangram's frequency analysis identifies which emoji are the tells: checkmarks, warning signs and keycap numbers appear *"at rates hundreds of times above the human baseline, whereas humans use faces to express themselves far more often than AI"*. Markdown density is 12× the human rate, bullet lists 9×.
+
+**commune-wiki's README has sixteen H2 headings and every single one is emoji-prefixed** (`## ✨ Features`, `## 🎯 Who Is This For?`, `## 🚀 Quick Start`, …), plus nine emoji feature bullets. `CONTRIBUTING.md` is the same. This is currently the most damaging file in the repo.
+
+### 5.3 "It's just markdown" — the dismissal commune must survive
+
+From the AGENTS.md launch thread (837 points):
+
+> **In what way is this a format or standard? It's just markdown in a namespce**
+> — <https://news.ycombinator.com/item?id=44957515>
+
+From the Claude Skills thread (816 points, 427 comments):
+
+> Upon further inspection **skills are effectively a bunch of markdown files and scripts** that get unzipped at the right time and used as context.
+> — <https://news.ycombinator.com/item?id=45607778>
+
+> Seems like a more organized way to do the equivalent of a folder full of md files + instructing the LLM to ls that folder
+> — <https://news.ycombinator.com/item?id=45607782>
+
+**"It's a folder of markdown" is not a defence — it is the accusation.** A project that is 90% prompt files has no answer to it. Commune's answer has to be the graph: a queryable index with a CLI surface and a JSON contract is a program, and can be demonstrated as one in a way a folder cannot. This is the strongest argument for [#18](https://github.com/dmthepm/commune-wiki/issues/18) landing *before* the skills in [#10](https://github.com/dmthepm/commune-wiki/issues/10).
+
+### 5.4 PKM fatigue is real, specific, and aimed at exactly this product
+
+Joan Westenberg deleted 10,000 notes after seven years:
+
+> **Instead of accelerating my thinking, it began to replace it. Instead of aiding memory, it froze my curiosity into static categories.**
+
+> I started reading to extract. Listening to summarize. Thinking in formats I could file. Every experience became fodder. **I stopped wondering and started processing.**
+
+The thread (598 points, 348 comments) is full of the same:
+
+> I tried to collect all thoughts, notes etc. but **I would never read them again.** Most of it would be outdated anyways.
+> — <https://news.ycombinator.com/item?id=44402648>
+
+> **The whole "second brain" thing seems like something you do to make a neat screenshot of your note graph.** I just use regular old folders like a file directory.
+> — <https://news.ycombinator.com/item?id=46238861>
+
+That last one is aimed directly at commune's most photogenic feature. **Do not lead with the graph visual.** Lead with what the graph is *for* — the connect step finding what a new dump touches before a draft exists.
+
+### 5.5 "Another one of these" — the highest-frequency killer
+
+From a Show HN for a markdown knowledge base (318 points, Apr 2026):
+
+> **Just another disposable piece of software maintained by a single person that does 80% of what other apps do but worse. Max lifespan 2 years**
+> — <https://news.ycombinator.com/item?id=47883025>
+
+> Doesn't Obsidian already do pretty much the same?
+> — <https://news.ycombinator.com/item?id=47883132>
+
+From an AI-augmented PKM Show HN the same week:
+
+> how is this different from pointing Claude Cowork at an Obsidian Vault?
+> — <https://news.ycombinator.com/item?id=47891154>
+
+> I feel like most of these applications all boil down to "**Obsidian but with AI integration baked in up front**". It'd be interesting to see approaches that actually rethink commonplaces of the experience rather than just reproduce the same thing but "with ai"
+> — <https://news.ycombinator.com/item?id=47893456>
+
+> It is the second llm wiki on frontpage today! I wish the scene was more collaborative - instead of everyone writing their own. But I guess this is **the llm curse - too easy to start.**
+> — <https://news.ycombinator.com/item?id=47892318>
+
+And the general form:
+
+> I feel like there's **not enough content on the landing page to help me understand why I need yet another notetaking app. The burden of proof is high** given how many of these there are.
+> — <https://news.ycombinator.com/item?id=49092157>
+
+**Commune's current README hands this objection a loaded weapon**: a vendor-authored comparison table against Obsidian, Notion, Roam and Logseq, claiming Obsidian is *"Desktop app, proprietary sync"* — while commune's own plan is to use Obsidian as its browsing surface. Delete it.
+
+### 5.6 The README that doesn't say what it does
+
+> The README.md doesn't really explain what it is or why I'd want it, just directory structure and how to install
+> — <https://news.ycombinator.com/item?id=47468597>
+
+> It is rather long-winded and have a lot of **bombastic claims but doesnt really explain what it does.**
+> — <https://news.ycombinator.com/item?id=46575471>
+
+> **within 2-3 minutes I'm not convinced why I care** and still don't know enough about what this is
+> — <https://news.ycombinator.com/item?id=48648184>
+
+### 5.7 The through-line
+
+Every anti-pattern above is the same failure: **the artifact reads as costless to produce, so the reader assigns it costless value.** Emoji bullets, bombastic claims, a folder of markdown, another PKM tool — each signals that no scarce human judgement was spent. The defences are all costly-signal moves: a demo that shows the thing running, a licence that matches the peer ecosystem rather than maximising leverage, spec-pure frontmatter that provably works in four harnesses, and prose a human clearly wrote and signed.
+
+---
+
+## 6. Constraints
+
+The deliverable. Each is actionable and mapped to a ticket where one exists.
+
+### Build
+
+**C1 — One install command, no prerequisites in it.** `npx skills add dmthepm/commune-wiki`, above the fold, nothing before it. Requires `skills/<name>/SKILL.md` at repo root. The Node CLI must be obtainable by the skill without a second manual step. ([#20](https://github.com/dmthepm/commune-wiki/issues/20)) *Counter-evidence in-house: morning-paper's front door is a 20-line paste prompt with a pinned Python and a Homebrew system library. Five stars.*
+
+**C2 — Skills shell out to the CLI. Never harness-specific APIs.** The precedent is already installed on this machine: *"This skill is intentionally shell-first so it works across agents that can run terminal commands, including Codex and Claude Code."* Portability is a consequence of the CLI boundary, not a feature to be added later. ([#10](https://github.com/dmthepm/commune-wiki/issues/10))
+
+**C3 — Spec-pure frontmatter, six fields only.** `name` (matching the directory), `description`, and optionally `license`, `compatibility`, `metadata`, `allowed-tools`. Anything else is a hard packaging error in Claude Code. Ship to both `.agents/skills/` and `.claude/skills/`; ship an `AGENTS.md` with a `CLAUDE.md` that imports it. ([#20](https://github.com/dmthepm/commune-wiki/issues/20))
+
+**C4 — The `description` is a trigger, not a summary.** Vercel measured skills never firing in 56% of eval cases. Write each `description` as the conditions under which the skill should activate, with the keywords a user would actually say. Corollary from the ETH study: put the operative contract *in* `AGENTS.md`, and do not write a repository overview — overviews measurably do not help and cost tokens. ([#10](https://github.com/dmthepm/commune-wiki/issues/10), [#6](https://github.com/dmthepm/commune-wiki/issues/6))
+
+**C5 — Exit codes describe whether the command ran, not what it found.** This revises the decision in [#2](https://github.com/dmthepm/commune-wiki/issues/2) ("0 clean / 1 findings / 2 error"). Adopt: `0` ran, `1` could not finish, `2` invalid invocation, `130` interrupted. Findings live in the JSON payload. If a hook needs a gate, add a separate status verb that encodes state in its exit code. Harness env vars (`CLAUDECODE`, `CODEX_SHELL`, `CURSOR_AGENT`) must not switch output format — the flag does. ([#9](https://github.com/dmthepm/commune-wiki/issues/9), [#18](https://github.com/dmthepm/commune-wiki/issues/18))
+
+**C6 — A `commune demo` that produces a real artifact, offline, in one command.** Bundled sample dictation in, real linked notes plus a graph query plus a built page out, no config and no network. The success criterion is stated as a refusal, morning-paper style: not "install succeeded" but "notes exist on disk and the graph answers a query." ([#11](https://github.com/dmthepm/commune-wiki/issues/11))
+
+**C7 — Bare `commune` prints concise help with examples first.** Per `clig.dev`: a description, one or two example invocations, and a pointer to `--help`. Something on stdout inside 100ms. Errors rewritten for humans with the fix in the message. Never require an interactive prompt — every command must be scriptable. ([#9](https://github.com/dmthepm/commune-wiki/issues/9))
+
+**C8 — `SKILL.md` under 100 lines; everything else in `references/`, loaded on demand.** The spec recommends under 5000 tokens and under 500 lines; the working examples are far tighter — `monologue-notes` is 77 lines, and `greptile-cli` states *"Prefer this reference over running `greptile <cmd> --help`."* ([#10](https://github.com/dmthepm/commune-wiki/issues/10))
+
+**C9 — Job-split with a router and a written invocation rule.** One skill per job in `dump → connect → grill → draft → refine → ship`, one user-invoked router (Pocock's `ask-matt` carries `disable-model-invocation: true`), and the rule that a user-invoked skill may call model-invoked skills but never another user-invoked one — written down before the second skill is authored. ([#19](https://github.com/dmthepm/commune-wiki/issues/19), [#10](https://github.com/dmthepm/commune-wiki/issues/10))
+
+**C10 — The graph ships before the skills.** §5.3's "it's just markdown" dismissal has no answer that is itself markdown. A queryable index with a JSON contract is demonstrably a program. Land [#18](https://github.com/dmthepm/commune-wiki/issues/18) before [#10](https://github.com/dmthepm/commune-wiki/issues/10).
+
+**C11 — Ask before installing anything.** Greptile: *"Do not install the CLI without asking."* Applies to the CLI, to Obsidian plugins, and to anything the setup skill would place in a user's home directory.
+
+**C12 — Defer to the host's primitives.** Do not build scheduling, a plugin marketplace, or a second skills installer. morning-paper: *"Morning Paper should not invent a second scheduling system unless you ask for a local fallback."*
+
+**C13 — Licence: change AGPL-3.0 to MIT.** *Flagged as a decision for Devon, not made here.* The evidence: Google's policy bans **installing** AGPL software on employee machines without OSPO authorisation; zero agent CLIs are AGPL; the note/wiki ecosystem is ~80% MIT; Devon's own two best-performing repos are MIT. Apache-2.0 is the defensible alternative if the patent grant is wanted, at the cost of §4 notice compliance and GPLv2 incompatibility. AGPL is currently protecting a static-site generator from a hosted competitor that does not exist. Note this touches `LICENSE`, `package.json` and devon-wiki, and needs a deliberate decision because relicensing later without a CLA requires unanimous contributor consent.
+
+### Presentation
+
+**C14 — The GitHub repo description is the positioning line. Set it.** Currently `null`, along with topics and homepage. `standard-readme` requires the README's short description to match it and to be under 120 characters. This is a five-minute fix on the highest-traffic surface in the project.
+
+**C15 — First screenful: name, claim, enemy, one install command.** Nothing else. Today line 3 of the README is `**License**: AGPL-3.0 / **Status**: Active Development`, before the reader has been given a reason to care. `npx skills` gets its entire hero into 15 lines.
+
+**C16 — Organise the README by failure mode, not by feature.** Pocock's structure: numbered failure mode → epigraph → stated Problem → the skill that is the Fix. Commune's four: *the dump never becomes a note; the note never gets linked; the claim never gets tested; the wiki stops being edited.* This also kills the `## ✨ Features` list, which is the section §5.1 readers bail on.
+
+**C17 — Delete every emoji heading.** Sixteen in `README.md`, more in `CONTRIBUTING.md`. Specifically named as an AI tell in §5.2. None of the adopted references does this.
+
+**C18 — Delete the comparison table.** Vendor-authored comparisons against Obsidian, Notion, Roam and Logseq read as marketing, and commune's runs on Obsidian — the table argues against commune's own architecture.
+
+**C19 — One VHS-scripted demo GIF at the top, ~60 seconds, inlined.** VHS over asciinema because a `.tape` file is diffable and regenerable in CI, so the demo cannot drift from the CLI; asciinema does not render inline on GitHub without `agg`. Show the real terminal: dictation in, a linked note and a built page out. Charm: *"showing the product."*
+
+**C20 — Lead with provenance, not promise.** Pocock's entire claim is *"Straight from my .agents directory"*. Commune's equivalent is devon-wiki: live at devonmeadows.com, ~74 notes, running this engine. Say it, link it, count it. That is the proof no README copy can fake and the direct answer to *"max lifespan 2 years."*
+
+**C21 — Publish the ADRs.** The map's "Charting decisions" entries — Node over Rust and Python, `npx skills` over a Claude-only plugin, markdown config over `commune.config.ts`, dictation over Obsidian as the writing surface — are already written and already good. Put them in the repo and link them from the README, as Pocock and Every both do. Reasoning in public is the respect mechanism.
+
+**C22 — Human-written, human-signed prose.** Willison's line is the standard: *"I attach my name and stake my credibility on the things that I publish."* Agent-drafted is fine; unreviewed is not. This applies with particular force to a tool whose product is generated notes — §5.1 shows the reader who suspects the README will assume the same of the output.
+
+---
+
+## 7. Open questions
+
+- **Is `grill` demonstrable in a 60-second GIF?** It is the differentiating step (§3.4) and the hardest to show, because its value is in the pushback quality. If it cannot be shown, C19's demo should lead with `connect` instead and `grill` should be the README's second section.
+- **What is the falsifiable claim for note quality?** Positioning candidate A promises a maintained canon. Nothing in this brief establishes how a visitor verifies that in thirty seconds. A public diff of a note across three revisions might do it.
+- **Does the AGENTS.md finding (§4.5) change [#6](https://github.com/dmthepm/commune-wiki/issues/6)?** The durable markdown context files were specified as the config surface. The ETH study says instructions are followed and overviews are not — so the durable files should read as rules, not as descriptions of the project. Worth re-reading #6 against that.
+- **Name and npm scope.** `package.json` currently says `commune-publish`. The bin name, the skill directory name and the `npx skills add` path all have to agree, and the positioning line should survive the choice.
+
+## 8. Sources
+
+**Compound engineering** — Klaassen, ["My AI Had Already Fixed the Code Before I Saw It"](https://every.to/source-code/my-ai-had-already-fixed-the-code-before-i-saw-it) (2025-08-18) · Shipper & Klaassen, ["Compound Engineering: How Every Codes With Agents"](https://web.archive.org/web/20251216042234/https://every.to/chain-of-thought/compound-engineering-how-every-codes-with-agents) (2025-12-11, Wayback) · [Every's Compound Engineering guide](https://every.to/guides/compound-engineering) · Klaassen, ["Compound Engineering Gets an Upgrade"](https://every.to/p/compound-engineering-gets-an-upgrade) (2026-05-29) · Larson, ["Learning from Every's Compound Engineering"](https://lethain.com/everyinc-compound-engineering/) (2026-01-19) · MoClaw, ["What Compound Engineering Actually Compounds"](https://moclaw.ai/blog/compound-engineering) (2026-08-07)
+
+**Reference projects** — [vercel-labs/skills](https://github.com/vercel-labs/skills) · [mattpocock/skills](https://github.com/mattpocock/skills) · [EveryInc/monologue-toolkit](https://github.com/EveryInc/monologue-toolkit) · [EveryInc/compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin) · [dmthepm/morning-paper](https://github.com/dmthepm/morning-paper) · `greptile-cli` SKILL.md and `references/output.md` as installed at `~/.agents/skills/greptile-cli`
+
+**Specs and standards** — [agentskills.io specification](https://agentskills.io/specification) · [Adding skills support](https://agentskills.io/client-implementation/adding-skills-support.md) · [agents.md](https://agents.md/) · [Claude Code memory docs](https://code.claude.com/docs/en/memory) · [Anthropic, "Equipping agents for the real world with Agent Skills"](https://www.anthropic.com/engineering/equipping-agents-for-the-real-world-with-agent-skills) (2025-10-16) · [Linux Foundation, Agentic AI Foundation](https://www.linuxfoundation.org/press/linux-foundation-announces-the-formation-of-the-agentic-ai-foundation) (2025-12-09)
+
+**Evidence against the default assumptions** — Gloaguen, Mündler, Müller, Raychev, Vechev, ["Evaluating AGENTS.md"](https://arxiv.org/abs/2602.11988) (arXiv:2602.11988) · [Vercel, "AGENTS.md outperforms Skills in our agent evals"](https://vercel.com/blog/agents-md-outperforms-skills-in-our-agent-evals) (2026-01-27)
+
+**CLI and README craft** — [clig.dev](https://clig.dev) · [12 Factor CLI Apps](https://medium.com/@jdxcode/12-factor-cli-apps-dd3c227a0e46) · [Art of README](https://github.com/hackergrrl/art-of-readme) · [standard-readme spec](https://github.com/RichardLitt/standard-readme/blob/main/spec.md) · [Charm, "100k"](https://charm.land/blog/100k/) · [VHS](https://github.com/charmbracelet/vhs) · [asciinema](https://github.com/asciinema/asciinema) · [Diátaxis](https://diataxis.fr)
+
+**Licensing** — [Google AGPL policy](https://opensource.google/documentation/reference/using/agpl-policy) · [Google releasing guidance](https://opensource.google/documentation/reference/releasing/preparing) · [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) · [FSF licence recommendations](https://www.gnu.org/licenses/license-recommendations.html) · [choosealicense.com](https://choosealicense.com) · [Blue Oak Council licence list](https://blueoakcouncil.org/list)
+
+**Anti-patterns** — Willison, ["Slop"](https://simonwillison.net/2024/May/8/slop/) (2024-05-08) · Westenberg, "I Deleted My Second Brain" ([HN thread](https://news.ycombinator.com/item?id=44402470)) · [Pangram, "Signs of AI writing"](https://www.pangram.com/signs-of-ai-writing) · [LeadDev, "Open source has a big AI slop problem"](https://leaddev.com/software-quality/open-source-has-a-big-ai-slop-problem) (2026-02-17) · individual HN comments cited inline
+
+**Method note.** Claims about `npx skills`, `monologue-notes`, `greptile-cli` and `mattpocock/skills` internals were verified against the copies installed on this machine under `~/.agents/skills/` and `~/.agents/.skill-lock.json`, not from documentation alone. Star counts, licences and repo metadata come from the GitHub and npm REST APIs on 2026-09-02. Where a source is paywalled (the remainder of both Klaassen essays), that is noted rather than paraphrased. Three findings are explicitly inference and are labelled as such in the text: the absence of adversarial HN discussion of compound engineering, the reason for the 62-vs-24,763 star gap inside Every, and the reading that an absent LICENSE file makes `monologue-toolkit` unreusable.
+
+**Known gaps.** Reddit was unreachable during this research, so §5's developer discourse is Hacker News-only — quotes were pulled from HN's Algolia API rather than paraphrased from search results, so they are exact, but the sampling is narrower than ideal. Three claims that would strengthen the constraints have no credible public evidence and are flagged inline rather than asserted: install-funnel drop-off for CLI tools (§4.1), any causal link between a hero GIF and adoption (§4.4), and any instrumented effect of zero-config first runs (§4.2). Where a vendor publishes an adoption number without an audit trail, it is not used here.


### PR DESCRIPTION
Four research notes written on 2026-09-01 and 2026-09-02 were left on `research/*` branches and never merged, while the plans that cite them (#18, #33, #10) are on main. Cherry-picked as-is, one commit each, so the dates and provenance stay:

- `docs/research/2026-09-01-file-dep-ts-consumption.md` (#5)
- `docs/research/2026-09-02-obsidian-graph-access.md` (#14)
- `docs/research/2026-09-02-obsidian-wikilink-resolution.md` (#15)
- `docs/research/2026-09-02-positioning-and-adoption.md` (#16)

Docs only, no package change. The four branches get deleted once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1XXFXAsDP1ftHkaRbgwwz