### PR TITLE
docs(#81): align the README and the skills with the accepted vision

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
-# Commune
+# Commune: keep your thinking connected
 
-A wiki engine for Astro, and a CLI that queries the wiki's link graph without running a build.
+Commune helps you maintain a personal wiki from markdown notes, dictated thoughts and everyday work. Its CLI finds connections while you write, optional agent skills help you question and revise your notes, and its Astro engine publishes linked notes with backlinks and markdown source twins. MIT licensed; your files stay yours.
 
-Write markdown. Link notes with `[[double brackets]]`. Get a static site where every link resolves both ways, every page has a plain-markdown twin, and the whole graph is one JSON file you can also query from a terminal.
+- **See it:** explore [devon.md](https://devon.md).
+- **Build a wiki:** follow [Install](#install), starting with Astro 7 and Node 22.12+.
+- **Try the writing loop:** on an existing Commune wiki, follow [Author with the skills](#author-with-the-skills).
 
-MIT. It runs [devon.md](https://devon.md).
+## Vision and mission
+
+**Vision:** People can keep their thinking connected, current and in their own hands, and share it in public as it develops.
+
+**Mission:** Commune turns markdown notes, dictated thoughts and the residue of everyday work into a maintained personal wiki through a shared link graph, authoring tools and portable publishing.
+
+Commune grew out of [devon.md](https://devon.md). Devon built his own site and recognised the structure afterward, then extracted its tools so a friend could inherit the learnings. It is an MIT project with no company behind it and no plans for monetization.
 
 ## Install
 
@@ -94,13 +102,13 @@ That route is a starting point, not an interface. The package ships the mechanis
 
 ## What ships
 
-- **WikiLinks.** `[[Title]]` and `[[Title|Display text]]` become real hrefs at build time, matched against titles and aliases. A link that resolves to nothing stays plain text instead of rendering a dead anchor.
+- **WikiLinks.** Connect notes with `[[Title]]`, using the target title verbatim and rewriting the sentence around it. The renderer also resolves aliases and `[[Title|Display text]]`, but `check` and `gate` report these noncanonical spellings. A link that resolves to nothing stays plain text instead of rendering a dead anchor.
 - **Backlinks.** The build writes `backlinks.json` — every entry with its inbound and outbound edges — to `dist/` and `public/`. `Backlinks.astro` renders it on a page.
 - **Markdown twins.** Every published content entry gets its source written beside it, so `/notes/hello/` also answers at `/notes/hello.md`. Entries in the content directories only — a hand-written route under `src/pages/` has no source file to twin. Agents and readers get the same document without scraping HTML.
 - **External links.** Anything off your `site` origin gets `target="_blank" rel="noopener noreferrer"` without you marking it up.
 - **The graph as a library.** `@dmthepm/commune/graph` exports the content loader, the link resolver and the graph builder. The Astro build and the CLI both call it. That is the point: one resolver, not two that drift.
 - **Updates.** A fourth collection, `src/content/updates/`, for the dated entries that say what changed. `Updates.astro` renders the newest few as a card. See [Updates](#updates) below.
-- **Honest dates.** `updated:` in frontmatter wins where you wrote one; where you did not, the date comes from the file's last commit, and from its mtime in a tree with no history. Every entry says which, so a page can show the honest one. See [Dates](#dates) below.
+- **Dates with sources.** `updated:` in frontmatter wins where you wrote one; where you did not, the date comes from the file's last commit, and from its mtime in a tree with no history. Every entry says which, so a page can show where the date came from. See [Dates](#dates) below.
 - **A site-wide last-updated.** The build writes `site.json` beside `backlinks.json`: the newest date across the whole wiki, which entry it belongs to, and the newest commit date whatever the entries claim.
 - **Components and stylesheets.** `@dmthepm/commune/components/*.astro` and `@dmthepm/commune/styles/*.css`, shipped as source. These are the components off my own site rather than a theme system — take them as a starting point, not an API.
 
@@ -172,7 +180,7 @@ links:
 I rewrote the home note. [[Atomic Notes]] and [[Evergreen Notes]] are new.
 ```
 
-`links:` is the one place in frontmatter where a bare string is a link. Everywhere else a link has to be spelled `[[like this]]` — a page's own `url:` would otherwise become a self-edge — but `links:` means nothing else, so a title or a site path both resolve and both become real edges. Write it or don't: `[[wikilinks]]` in the body work the same way, and naming a page in both places is still one edge.
+`links:` is the one place in frontmatter where a bare string is a link. Everywhere else a link has to be spelled `[[like this]]`; a page's own `url:` would otherwise become a self-edge; but `links:` means nothing else, so a title or a site path both resolve and both become edges. Write it or don't: `[[wikilinks]]` in the body work the same way, and naming a page in both places is still one edge.
 
 Register the collection alongside your notes in `src/content.config.ts`:
 
@@ -228,7 +236,7 @@ export async function GET(context) {
 
 ## The CLI
 
-`commune` installs as a bin. It reads markdown off disk and answers without an Astro process running, which is what makes it useful while you are still writing.
+Find connections and check your notes while you write, without building the site. The `commune` executable reads markdown directly from disk and answers without an Astro process running.
 
 ```bash
 commune check
@@ -263,31 +271,37 @@ Every verb takes `--json` and emits one document on stdout with everything else 
 
 Exit codes report whether the command finished, never what it found — `0` finished, `1` could not finish, `2` invalid invocation. Findings live in the payload. A command that exits non-zero because it *found* something is indistinguishable, to a shell, from one that crashed. `gate` is the one deliberate exception: a gate's entire job is a yes/no and a build has to stop on it, so `gate` exits `1` when the build it checked is wrong.
 
-`commune --help` prints the full surface. `commune --version` prints the installed version, which is the honest way to know what you have.
+`commune --help` prints the full surface. `commune --version` prints the installed version, which is the way to know what you have.
 
 ## Author with the skills
 
-The loop above the CLI ships as four agent skills, in `skills/`, installed straight from this repository rather than from npm:
+Turn a dump into connected, reviewed writing with four agent skills, in `skills/`, installed straight from this repository rather than from npm:
 
 ```bash
 npx skills add dmthepm/commune-wiki
 ```
 
-They install for Claude Code and Codex, globally or into one project, and they drive the `commune` your wiki already has — `node_modules/.bin/commune`, called by path, never downloaded — so the CLI a skill runs is the one your site builds with. They need 0.4.0 or newer, they check that first, and they install nothing themselves.
+The skills install for Claude Code and Codex, globally or into one project. They call the wiki's existing `node_modules/.bin/commune` directly, so authoring and publishing use the same CLI. They require version 0.4.0 or newer, check it first and install nothing themselves.
 
-The loop is one dump, four files and two places it stops for you. `commune-dump` takes a dictated or pasted dump, writes it verbatim to `dumps/<date>-<slug>.md`, and asks the graph what it already touches — what it mentions, which of the target's links a rewrite would put at risk, which subjects have no note yet — into `dumps/<slug>.connect.md`. `commune-write` reads your `WRITING.md`, asks one short round of questions whose answers each change a file, stops while you answer them in `dumps/<slug>.answers.md`, then drafts into the real note and renders the original and the draft side by side as `dumps/<slug>.review.html`. `commune-ship` diffs `check` against the baseline, files the `updates` entry, builds, gates, greps `dist/` for every new href, commits and opens the PR — and never merges, because the last word is yours. `commune-setup` runs once per wiki and writes the `WRITING.md` the other three obey.
+`commune-setup` runs once per wiki and writes its `WRITING.md` rules. `commune-dump` saves dictated or pasted text verbatim to `dumps/<slug>.md` and records connection candidates and the check baseline in `dumps/<slug>.connect.md`. Here `<slug>` includes the capture date.
 
-Status, honestly: the skills, their test and the `WRITING.md` template are here. The loop has been run once end to end by hand, before it was skills; it has not yet been run as skills on a real wiki. That run is [#10](https://github.com/dmthepm/commune-wiki/issues/10), and this paragraph changes when it lands.
+`commune-write` asks one short round of editorial questions and waits for answers in `dumps/<slug>.answers.md`. It then drafts into the note and renders the original and draft side by side in `dumps/<slug>.review.html` for the author to review.
 
-## What it is not
+On the author's instruction, `commune-ship` compares finding identities against the baseline, files an update, builds, gates and verifies each new href and destination file. It commits according to `WRITING.md`'s `dumps.commit` policy, opens a PR and records the receipt in `dumps/<slug>.ship.md`. The author approves the content; this skill never merges. That boundary governs authored content, while code maintenance follows the repository's contribution rules.
 
-It is not a note-taking app and it is not trying to replace one. I write in Obsidian; Commune is what turns the vault into a site. There is no editor here, no sync, no account, no server. The graph is computed from files on disk at build time, and the files are yours whether or not you ever run this.
+The four skills, their tests and the `WRITING.md` template ship today. The loop was run once end to end by hand before the skills existed; an end-to-end run using the installed skills remains unverified.
+
+## Files and publishing
+
+Commune is not a note-taking app. It works with markdown files on disk, written in whatever editor you like, and provides no editor, sync service, account or server of its own. The files remain yours whether or not you ever run it.
+
+Only notes with `visibility: public` enter the graph and publishing output. Research, pages and updates are included regardless of visibility. Handoffs in `dumps/` are committed by default under the writing policy; they are outside the engine's content collections and do not automatically become site pages.
 
 ## Where this is going
 
-Commune is the engine under a larger idea: own your canon. The wiki is one output surface, not the product. What I am building toward is an authoring loop — dictate a dump, have agents find what it already connects to, grill it, draft it, ship it — where the graph is what makes connection-finding possible *before* a draft exists. That is why the graph is a queryable library with a CLI on top instead of a build artifact, and why `graph related` reads stdin.
+Commune ships an Astro publishing engine, a shared link graph, a CLI for finding and checking connections, and four authoring skills. Together they support maintaining existing thinking as well as adding notes. The engine and CLI install from npm; the optional skills install separately into an existing wiki.
 
-The authoring half of that loop is here now, as the four skills above; `pnpm add @dmthepm/commune` still gives you the engine and the CLI and nothing else, which is what those skills drive. What is left — the email destination, the weekly intake from GitHub activity — is tracked in [the issues](https://github.com/dmthepm/commune-wiki/issues).
+Three proofs are still owed: a repeated authoring run with the installed skills, a second person building a wiki and coming back to edit it a week later, and a session of browsing and light edits in Obsidian on a wiki of real size. Features follow what those sessions show is needed; they are tracked in [the issues](https://github.com/dmthepm/commune-wiki/issues).
 
 ## Deploy
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Commune helps you maintain a personal wiki from markdown notes, dictated thought
 
 **Mission:** Commune turns markdown notes, dictated thoughts and the residue of everyday work into a maintained personal wiki through a shared link graph, authoring tools and portable publishing.
 
-Commune grew out of [devon.md](https://devon.md). Devon built his own site and recognised the structure afterward, then extracted its tools so a friend could inherit the learnings. It is an MIT project with no company behind it and no plans for monetization.
+Commune grew out of [devon.md](https://devon.md). Devon built his own site and recognised the structure afterward, then extracted its tools so someone else could build on them. It is an MIT project with no company behind it and no plans for monetization.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@dmthepm/commune",
   "type": "module",
   "version": "0.5.2",
-  "description": "An Astro wiki engine with WikiLinks, sliding panes, backlinks and static search, plus a commune CLI that queries the content graph and checks links",
+  "description": "Maintain a personal wiki from markdown notes, dictated thoughts and everyday work with authoring tools, a shared link graph and portable Astro publishing.",
   "license": "MIT",
   "keywords": [
     "astro",

--- a/skills/commune-dump/SKILL.md
+++ b/skills/commune-dump/SKILL.md
@@ -47,7 +47,9 @@ one hyphen. Create `dumps/` if the wiki has none.
    exists, stop and say so; a dump is never overwritten.
 
 3. **Baseline, and the name collision.** Run `$COMMUNE check --json` and keep
-   `summary` as `baseline`. Two collision cases, one stop:
+   `summary` fields in `baseline`, plus `baseline.findings`: every finding
+   projected to `(rule, file, target)`, using `null` for an absent target.
+   Two collision cases, one stop:
    - The target exists: any `duplicate-name` finding naming its title or an
      alias.
    - The target is new: `check` cannot see a file that is not there, so compare

--- a/skills/commune-dump/references/handoffs.md
+++ b/skills/commune-dump/references/handoffs.md
@@ -8,6 +8,21 @@ able to read it.
 Any step can be re-run by a different context window or a different harness,
 because these four files are the whole state. Nothing is carried in a chat.
 
+`WRITING.md`'s Frontmatter section sets `dumps.publish: opt-in` for dump pages.
+The values are `never | opt-in | all`: `never` permits no dump pages; the default
+`opt-in` keeps dumps private unless their frontmatter says `visibility: public`,
+which makes them publishable; `all` makes every dump public. Setup asks this
+question first, then asks separately about committing handoffs.
+
+`WRITING.md`'s Frontmatter section sets `dumps.commit: true` by default.
+Setup asks once whether to keep that default or use `false`. Ship commits all
+four handoffs only for an explicit `true`; false, missing or invalid leaves
+every `dumps/` path out of the commit, even if tracked or staged. With `false`,
+setup adds `dumps/` to `.gitignore`; with `true`, it removes blocking ignore
+rules. Public repositories expose committed handoffs regardless of dump
+visibility. Ignoring a tracked file does not remove its existing history.
+This policy does not create site pages; the engine does not load `dumps/`.
+
 Names, from one dump slug `<yyyy-mm-dd>-<target-slug>`:
 
 | File | Written by | Read by |
@@ -36,9 +51,11 @@ visibility: private      # private | public — whether the dump itself is publi
 The body is never fenced and never indented as code. `graph related` strips code
 before it matches, so a fenced dump has no mentions at all.
 
-`visibility` is the dump's own, not the note's: `private` is the default and
-means the dump is provenance beside the notes, never a page. `public` means the
-wiki may publish it. `publish` is about the *note* the dump becomes.
+`visibility` belongs to the dump and defaults to `private`. Under
+`dumps.publish: opt-in`, only `visibility: public` makes a dump publishable as a
+page. `never` permits no dump pages and `all` makes every dump public regardless
+of visibility. The dump's `publish` field is about the *note* it becomes;
+`dumps.commit` separately controls whether handoffs enter repository history.
 
 ## `dumps/<slug>.connect.md` — what the graph already knows
 
@@ -47,11 +64,14 @@ wiki may publish it. `publish` is about the *note* the dump becomes.
 kind: connect
 dump: dumps/2026-09-05-<slug>.md
 cli: "@dmthepm/commune 0.4.0"
-baseline:                # check --json summary, before any edit
+baseline:                # check --json summary fields plus finding identities, before any edit
   entries: 85
   edges: 396
   errors: 1
   warnings: 0
+  byRule: { broken-link: 1, ambiguous-target: 0, duplicate-name: 0, noncanonical-title: 0 }
+  findings:
+    - { rule: broken-link, file: src/content/notes/example.md, target: Missing }
 duplicate_name: []       # check findings whose candidates include the target; non-empty = stopped
 target: { file: src/content/notes/<slug>.md, urlPath: /notes/<slug>/, inbound: 6, outbound: 11 }
 at_risk:                 # the target's resolved outbound links; each one the draft may drop
@@ -70,6 +90,13 @@ status: ready | blocked
 ## Candidates
 ## Handoff
 ```
+
+`baseline.findings` records every finding as `{ rule, file, target }`, using
+`null` when target is absent and `[]` when there are no findings. Write and ship
+compare these tuples as sets; summary totals are context only. Equal counts
+can conceal a new finding replacing an old one. If identities are missing,
+recover them from the pre-edit revision before comparing; never baseline the
+edited corpus.
 
 `mentions`, `unmatched` and `unreferenced` are candidates for the human. The
 draft is never scored on them: a mention the draft ignores is not a miss.
@@ -127,9 +154,10 @@ check:                  # against connect's baseline
   new_findings: []      # non-empty = ship stopped
 updates_entry: src/content/updates/2026-09-05.md
 aiGenerated: false      # false when the summary sentence is the human's, true when the agent wrote it
-hrefs:                  # every new or renamed urlPath, grepped in dist/
-  - { urlPath: /research/<slug>/, found: true }
-commit: <sha>
+hrefs:                  # new hrefs, including each created or renamed page and twin
+  - { urlPath: /research/<slug>/, found: true, destination: dist/research/<slug>/index.html, exists: true }
+  - { urlPath: /research/<slug>.md, found: true, destination: dist/research/<slug>.md, exists: true }
+commit: <content-commit-sha>
 pr: https://github.com/<owner>/<repo>/pull/<n>
 preview: https://<hash>.<project>.pages.dev/research/<slug>/
 review: dumps/<slug>.review.html
@@ -140,3 +168,10 @@ review: dumps/<slug>.review.html
 
 `commune-ship` never merges. The PR is where the human reads the page in the
 site's chrome and says ship or leaves a correction.
+
+Prepare the receipt before the content commit with commit, PR and preview
+pending. After opening the PR, fill those fields; `commit` identifies the
+content commit. When `dumps.commit: true`, commit the completed receipt in a
+follow-up commit and push it. Otherwise the receipt stays local. `found` records
+an href occurrence in built HTML; `exists` records the destination file check.
+Both must be true. The generated review HTML is separate from the four handoffs.

--- a/skills/commune-setup/SKILL.md
+++ b/skills/commune-setup/SKILL.md
@@ -51,19 +51,21 @@ questions only the wiki's owner can answer.
    this shape.
 
 4. **Ask the residue** — only the sections still holding a placeholder, plus the
-   two below. One message, numbered, recommended answer first, each question
+   two questions below. One message, numbered, recommended answer first, each question
    naming what it changes in the file.
 
-5. **The two questions that are never inferable.**
-   - **Dumps policy.** *"`dumps.publish: opt-in` — a dictated dump stays
-     provenance beside the notes unless its frontmatter says `visibility:
-     public`. `never` or `all` instead?"* Write the answer into the
-     **Frontmatter** section's dumps line.
-   - **Public repository.** Only when the repo is public: *"`dumps/` will be
-     readable by anyone with the URL. Add `dumps/` to `.gitignore` so the
-     handoffs live only on your machine?"* Recommend gitignoring on a public
-     repo and committing on a private one. If they gitignore it, say plainly
-     that the loop still works and the provenance is no longer in the history.
+5. **Ask both policy questions once, recommended answer first.**
+   - **Publish pages.** Recommend `dumps.publish: opt-in`: dumps are private
+     by default; only a dump with `visibility: public` is publishable as a page.
+     Ask whether to keep `opt-in`, choose `never` (no dump pages), or `all`
+     (every dump is public). Record the answer in **Frontmatter**.
+   - **Commit handoffs.** Recommend `dumps.commit: true`: commit all four
+     handoffs so another person can inherit the writing history. Explain that
+     public repositories expose their contents even with `visibility: private`.
+     Ask whether to keep `true` or set `false` to exclude handoffs from commits.
+     Record the boolean in **Frontmatter**. With `false`, add `dumps/` to
+     `.gitignore`; with `true`, remove ignore rules blocking handoffs. Ignoring
+     tracked files does not hide existing history. Committing does not create pages.
 
 6. **Write and verify.** Write `WRITING.md`. Then check yourself: no
    `<angle bracket>` remains; every frontmatter block's keys and values exist in

--- a/skills/commune-setup/assets/WRITING.md
+++ b/skills/commune-setup/assets/WRITING.md
@@ -29,8 +29,9 @@ Rules that change a sentence: length, person, what to cut.
 - **One idea per note.** <How to tell when it is two.>
 - **Proper nouns get their own note.** <Which ones: people, projects, products.
   The note says what the thing means here, then links out.>
-- **Linking:** <how densely, and where external links go — in the note, never as
-  the note.>
+- **Linking:** Use the target note's title verbatim in `[[Title]]`, with no
+  display text or pipe. Rewrite the sentence around the title.
+  <How densely to link, and where external links belong within the note.>
 
 ## Frontmatter
 
@@ -86,11 +87,20 @@ created: <yyyy-mm-dd>
 updated: <yyyy-mm-dd>
 ```
 
-**Dumps.** `dumps.publish: <never | opt-in | all>` — whether the dictated dumps
-in `dumps/` are ever published as pages. `never`: they stay provenance beside
-the notes. `opt-in`: a dump with `visibility: public` in its frontmatter is
-publishable, everything else is not. `all`: every dump is public. Default and
-recommendation: `opt-in`.
+**Dump pages.** `dumps.publish: opt-in` controls whether dictated dumps are
+published as pages. Values: `never | opt-in | all`. `never` means no dump pages;
+`opt-in` is the default, keeping dumps private unless their frontmatter says
+`visibility: public`, which makes them publishable; `all` makes every dump
+public. The engine does not automatically create pages from `dumps/`.
+
+**Handoff commits.** `dumps.commit: true` controls committing all four handoffs in
+`dumps/`. Setup asks once; `true` is the default so the writing history can be
+inherited. Set `false` to leave every `dumps/` path out of commits and add the
+directory to `.gitignore`. A public repository exposes committed handoffs,
+including dumps marked `visibility: private`. This setting does not publish
+site pages; `dumps/` is outside the engine's content collections. Ship includes
+handoffs only when this line explicitly says `true`; missing or invalid means
+leave them out.
 
 ## Avoid
 

--- a/skills/commune-ship/SKILL.md
+++ b/skills/commune-ship/SKILL.md
@@ -20,7 +20,7 @@ step 1 prints. Handoff file shapes: `references/handoffs.md`.
 - **Never merge.** Open the PR and stop. Voice is the human's, and the PR is
   where they read the page in the site's chrome.
 - A green `check` is not proof the page exists. It did not catch a note whose
-  file name and title disagreed shipping a 404. Step 6 is what catches that.
+  file name and title disagreed shipping a 404. Step 5 is what catches that.
 - Pre-existing findings are the baseline, not your problem. **New** findings
   are, and they stop the ship.
 - Never install anything.
@@ -28,12 +28,14 @@ step 1 prints. Handoff file shapes: `references/handoffs.md`.
 ## Steps
 
 1. **Preflight and read.** `node scripts/preflight.mjs` → `$COMMUNE`; stop on
-   exit 1. Read `dumps/<slug>.connect.md` for `files:` and `baseline:`, and
+   exit 1. Read `WRITING.md` for `dumps.commit`. Read `dumps/<slug>.connect.md` for `files:` and `baseline:`, and
    `dumps/<slug>.answers.md` for what was decided. Pipe every `--json` payload
-   through `node scripts/preflight.mjs --schema`.
+   through `node scripts/preflight.mjs --schema`. Compare finding identities
+   `(rule, file, target)` with `baseline.findings`, using `null` for absent targets.
 
-2. **Check against the baseline.** `$COMMUNE check --json`. Compare `summary`
-   to `baseline`. Any finding that is not in the baseline stops the ship: say
+2. **Check against the baseline.** `$COMMUNE check --json`. Compare identities as sets, never counts.
+   A missing `baseline.findings` requires recovering the pre-edit findings;
+   never treat the edited corpus as its own baseline. Any finding that is not in the baseline stops the ship: say
    which file and which rule, and hand back to `commune-write`.
 
 3. **File the updates entry.** `$COMMUNE update --recent <dump date> --json`
@@ -53,25 +55,32 @@ step 1 prints. Handoff file shapes: `references/handoffs.md`.
    without the build. `gate` exits 1 when the built site is wrong; that stops
    the ship.
 
-5. **Confirm every new href.** For each entry the file set created or renamed,
-   read its `urlPath` from `$COMMUNE graph query --json` and grep `dist/` for
-   it. Missing means the page did not render at the URL the graph promises —
-   a 404 that `check` cannot see.
+5. **Confirm every new href.** For each created or renamed entry, read its
+   `urlPath` from `$COMMUNE graph query --json`. Require both an href occurrence
+   in built HTML and an existing destination under `dist/`: `/path/` maps to
+   `dist/path/index.html`; its `/path.md` twin maps to `dist/path.md`. Check both
+   URLs, stripping query and fragment before mapping; `/` maps to `dist/index.html`.
+   Also check new internal links in edited files, including existing destinations.
+   Record occurrence and destination existence separately; either missing stops ship.
 
-6. **Commit and open the PR.** Commit exactly the paths in `files:` plus the
-   updates entry and the four `dumps/` handoff files. Conventional message,
-   subject in the wiki's own convention. Push the branch. Open the PR with the
-   preview URL and `dumps/<slug>.review.html` in the body, and the `summary`
-   sentence quoted so it can be corrected in one reply.
+6. **Commit and open the PR.** Prepare the receipt first with commit, PR and
+   preview pending. Commit exactly `files:` plus the updates entry; include the
+   four handoffs only when `WRITING.md` says `dumps.commit: true`. Otherwise
+   exclude every `dumps/` path, even if listed in `files:` or already staged.
+   Never use a blanket add. Use the wiki's conventional commit subject. Push and
+   open the PR with the preview URL and summary sentence. Include the review
+   path only when handoffs are shared; otherwise describe the review in the PR.
 
-7. **Write the receipt.** Output: `dumps/<slug>.ship.md`, keys per
-   `references/handoffs.md` — the check diff, the hrefs, the updates entry, the
-   commit, the PR URL, the preview URL. Print the PR URL and stop.
+7. **Finish the receipt.** Update `dumps/<slug>.ship.md` per
+   `references/handoffs.md` with the check diff, href checks, updates entry,
+   content commit, PR and preview URLs. When `dumps.commit: true`, commit this
+   receipt update separately and push; its `commit` names the content commit.
+   Otherwise keep it local. Print the PR URL and stop.
 
 ## Stop conditions
 
 - A new `check` finding → stop, name it, hand back to `commune-write`.
 - `gate` exits 1 → stop, quote its finding.
-- An href missing from `dist/` → stop. That is the 404 this step exists for.
+- An href occurrence or destination file missing from `dist/` → stop. That is the 404 this step exists for.
 - No preview URL yet (the deployment has not finished) → open the PR anyway and
   say the preview is pending; do not wait, and do not merge.

--- a/skills/commune-ship/references/handoffs.md
+++ b/skills/commune-ship/references/handoffs.md
@@ -8,6 +8,21 @@ able to read it.
 Any step can be re-run by a different context window or a different harness,
 because these four files are the whole state. Nothing is carried in a chat.
 
+`WRITING.md`'s Frontmatter section sets `dumps.publish: opt-in` for dump pages.
+The values are `never | opt-in | all`: `never` permits no dump pages; the default
+`opt-in` keeps dumps private unless their frontmatter says `visibility: public`,
+which makes them publishable; `all` makes every dump public. Setup asks this
+question first, then asks separately about committing handoffs.
+
+`WRITING.md`'s Frontmatter section sets `dumps.commit: true` by default.
+Setup asks once whether to keep that default or use `false`. Ship commits all
+four handoffs only for an explicit `true`; false, missing or invalid leaves
+every `dumps/` path out of the commit, even if tracked or staged. With `false`,
+setup adds `dumps/` to `.gitignore`; with `true`, it removes blocking ignore
+rules. Public repositories expose committed handoffs regardless of dump
+visibility. Ignoring a tracked file does not remove its existing history.
+This policy does not create site pages; the engine does not load `dumps/`.
+
 Names, from one dump slug `<yyyy-mm-dd>-<target-slug>`:
 
 | File | Written by | Read by |
@@ -36,9 +51,11 @@ visibility: private      # private | public — whether the dump itself is publi
 The body is never fenced and never indented as code. `graph related` strips code
 before it matches, so a fenced dump has no mentions at all.
 
-`visibility` is the dump's own, not the note's: `private` is the default and
-means the dump is provenance beside the notes, never a page. `public` means the
-wiki may publish it. `publish` is about the *note* the dump becomes.
+`visibility` belongs to the dump and defaults to `private`. Under
+`dumps.publish: opt-in`, only `visibility: public` makes a dump publishable as a
+page. `never` permits no dump pages and `all` makes every dump public regardless
+of visibility. The dump's `publish` field is about the *note* it becomes;
+`dumps.commit` separately controls whether handoffs enter repository history.
 
 ## `dumps/<slug>.connect.md` — what the graph already knows
 
@@ -47,11 +64,14 @@ wiki may publish it. `publish` is about the *note* the dump becomes.
 kind: connect
 dump: dumps/2026-09-05-<slug>.md
 cli: "@dmthepm/commune 0.4.0"
-baseline:                # check --json summary, before any edit
+baseline:                # check --json summary fields plus finding identities, before any edit
   entries: 85
   edges: 396
   errors: 1
   warnings: 0
+  byRule: { broken-link: 1, ambiguous-target: 0, duplicate-name: 0, noncanonical-title: 0 }
+  findings:
+    - { rule: broken-link, file: src/content/notes/example.md, target: Missing }
 duplicate_name: []       # check findings whose candidates include the target; non-empty = stopped
 target: { file: src/content/notes/<slug>.md, urlPath: /notes/<slug>/, inbound: 6, outbound: 11 }
 at_risk:                 # the target's resolved outbound links; each one the draft may drop
@@ -70,6 +90,13 @@ status: ready | blocked
 ## Candidates
 ## Handoff
 ```
+
+`baseline.findings` records every finding as `{ rule, file, target }`, using
+`null` when target is absent and `[]` when there are no findings. Write and ship
+compare these tuples as sets; summary totals are context only. Equal counts
+can conceal a new finding replacing an old one. If identities are missing,
+recover them from the pre-edit revision before comparing; never baseline the
+edited corpus.
 
 `mentions`, `unmatched` and `unreferenced` are candidates for the human. The
 draft is never scored on them: a mention the draft ignores is not a miss.
@@ -127,9 +154,10 @@ check:                  # against connect's baseline
   new_findings: []      # non-empty = ship stopped
 updates_entry: src/content/updates/2026-09-05.md
 aiGenerated: false      # false when the summary sentence is the human's, true when the agent wrote it
-hrefs:                  # every new or renamed urlPath, grepped in dist/
-  - { urlPath: /research/<slug>/, found: true }
-commit: <sha>
+hrefs:                  # new hrefs, including each created or renamed page and twin
+  - { urlPath: /research/<slug>/, found: true, destination: dist/research/<slug>/index.html, exists: true }
+  - { urlPath: /research/<slug>.md, found: true, destination: dist/research/<slug>.md, exists: true }
+commit: <content-commit-sha>
 pr: https://github.com/<owner>/<repo>/pull/<n>
 preview: https://<hash>.<project>.pages.dev/research/<slug>/
 review: dumps/<slug>.review.html
@@ -140,3 +168,10 @@ review: dumps/<slug>.review.html
 
 `commune-ship` never merges. The PR is where the human reads the page in the
 site's chrome and says ship or leaves a correction.
+
+Prepare the receipt before the content commit with commit, PR and preview
+pending. After opening the PR, fill those fields; `commit` identifies the
+content commit. When `dumps.commit: true`, commit the completed receipt in a
+follow-up commit and push it. Otherwise the receipt stays local. `found` records
+an href occurrence in built HTML; `exists` records the destination file check.
+Both must be true. The generated review HTML is separate from the four handoffs.

--- a/skills/commune-write/SKILL.md
+++ b/skills/commune-write/SKILL.md
@@ -16,6 +16,9 @@ step 1 prints. Handoff file shapes: `references/handoffs.md`.
 
 ## Rules
 
+- Use the target note's title verbatim in `[[Title]]`, with no display text
+  or pipe. Rewrite the sentence around the title.
+
 - `WRITING.md` at the wiki root decides every sentence and every frontmatter
   block. Read it first and read nothing else about voice. If it is missing,
   stop and say: *"Run `commune-setup` first — this wiki has no `WRITING.md`."*
@@ -51,8 +54,8 @@ step 1 prints. Handoff file shapes: `references/handoffs.md`.
    keys in its order. Append every file you touched to `files:` in
    `.connect.md`.
 
-4. **Verify.** Run `$COMMUNE check --json` and diff `summary` against
-   `baseline` in `.connect.md`. Any **new** finding is yours to fix before you
+4. **Verify.** Run `$COMMUNE check --json` and compare finding identities `(rule, file, target)` against
+   `baseline.findings` in `.connect.md`. Any **new** finding is yours to fix before you
    show anything; pre-existing findings are the baseline and are not. Then
    `$COMMUNE graph related <target> --json` for what the note now links.
 

--- a/skills/commune-write/SKILL.md
+++ b/skills/commune-write/SKILL.md
@@ -54,8 +54,8 @@ step 1 prints. Handoff file shapes: `references/handoffs.md`.
    keys in its order. Append every file you touched to `files:` in
    `.connect.md`.
 
-4. **Verify.** Run `$COMMUNE check --json` and compare finding identities `(rule, file, target)` against
-   `baseline.findings` in `.connect.md`. Any **new** finding is yours to fix before you
+4. **Verify.** Run `$COMMUNE check --json` and compare finding identities `(rule, file, target)`,
+   `null` for an absent target, against `baseline.findings` in `.connect.md`. Any **new** finding is yours to fix before you
    show anything; pre-existing findings are the baseline and are not. Then
    `$COMMUNE graph related <target> --json` for what the note now links.
 

--- a/skills/commune-write/references/handoffs.md
+++ b/skills/commune-write/references/handoffs.md
@@ -8,6 +8,21 @@ able to read it.
 Any step can be re-run by a different context window or a different harness,
 because these four files are the whole state. Nothing is carried in a chat.
 
+`WRITING.md`'s Frontmatter section sets `dumps.publish: opt-in` for dump pages.
+The values are `never | opt-in | all`: `never` permits no dump pages; the default
+`opt-in` keeps dumps private unless their frontmatter says `visibility: public`,
+which makes them publishable; `all` makes every dump public. Setup asks this
+question first, then asks separately about committing handoffs.
+
+`WRITING.md`'s Frontmatter section sets `dumps.commit: true` by default.
+Setup asks once whether to keep that default or use `false`. Ship commits all
+four handoffs only for an explicit `true`; false, missing or invalid leaves
+every `dumps/` path out of the commit, even if tracked or staged. With `false`,
+setup adds `dumps/` to `.gitignore`; with `true`, it removes blocking ignore
+rules. Public repositories expose committed handoffs regardless of dump
+visibility. Ignoring a tracked file does not remove its existing history.
+This policy does not create site pages; the engine does not load `dumps/`.
+
 Names, from one dump slug `<yyyy-mm-dd>-<target-slug>`:
 
 | File | Written by | Read by |
@@ -36,9 +51,11 @@ visibility: private      # private | public — whether the dump itself is publi
 The body is never fenced and never indented as code. `graph related` strips code
 before it matches, so a fenced dump has no mentions at all.
 
-`visibility` is the dump's own, not the note's: `private` is the default and
-means the dump is provenance beside the notes, never a page. `public` means the
-wiki may publish it. `publish` is about the *note* the dump becomes.
+`visibility` belongs to the dump and defaults to `private`. Under
+`dumps.publish: opt-in`, only `visibility: public` makes a dump publishable as a
+page. `never` permits no dump pages and `all` makes every dump public regardless
+of visibility. The dump's `publish` field is about the *note* it becomes;
+`dumps.commit` separately controls whether handoffs enter repository history.
 
 ## `dumps/<slug>.connect.md` — what the graph already knows
 
@@ -47,11 +64,14 @@ wiki may publish it. `publish` is about the *note* the dump becomes.
 kind: connect
 dump: dumps/2026-09-05-<slug>.md
 cli: "@dmthepm/commune 0.4.0"
-baseline:                # check --json summary, before any edit
+baseline:                # check --json summary fields plus finding identities, before any edit
   entries: 85
   edges: 396
   errors: 1
   warnings: 0
+  byRule: { broken-link: 1, ambiguous-target: 0, duplicate-name: 0, noncanonical-title: 0 }
+  findings:
+    - { rule: broken-link, file: src/content/notes/example.md, target: Missing }
 duplicate_name: []       # check findings whose candidates include the target; non-empty = stopped
 target: { file: src/content/notes/<slug>.md, urlPath: /notes/<slug>/, inbound: 6, outbound: 11 }
 at_risk:                 # the target's resolved outbound links; each one the draft may drop
@@ -70,6 +90,13 @@ status: ready | blocked
 ## Candidates
 ## Handoff
 ```
+
+`baseline.findings` records every finding as `{ rule, file, target }`, using
+`null` when target is absent and `[]` when there are no findings. Write and ship
+compare these tuples as sets; summary totals are context only. Equal counts
+can conceal a new finding replacing an old one. If identities are missing,
+recover them from the pre-edit revision before comparing; never baseline the
+edited corpus.
 
 `mentions`, `unmatched` and `unreferenced` are candidates for the human. The
 draft is never scored on them: a mention the draft ignores is not a miss.
@@ -127,9 +154,10 @@ check:                  # against connect's baseline
   new_findings: []      # non-empty = ship stopped
 updates_entry: src/content/updates/2026-09-05.md
 aiGenerated: false      # false when the summary sentence is the human's, true when the agent wrote it
-hrefs:                  # every new or renamed urlPath, grepped in dist/
-  - { urlPath: /research/<slug>/, found: true }
-commit: <sha>
+hrefs:                  # new hrefs, including each created or renamed page and twin
+  - { urlPath: /research/<slug>/, found: true, destination: dist/research/<slug>/index.html, exists: true }
+  - { urlPath: /research/<slug>.md, found: true, destination: dist/research/<slug>.md, exists: true }
+commit: <content-commit-sha>
 pr: https://github.com/<owner>/<repo>/pull/<n>
 preview: https://<hash>.<project>.pages.dev/research/<slug>/
 review: dumps/<slug>.review.html
@@ -140,3 +168,10 @@ review: dumps/<slug>.review.html
 
 `commune-ship` never merges. The PR is where the human reads the page in the
 site's chrome and says ship or leaves a correction.
+
+Prepare the receipt before the content commit with commit, PR and preview
+pending. After opening the PR, fill those fields; `commit` identifies the
+content commit. When `dumps.commit: true`, commit the completed receipt in a
+follow-up commit and push it. Otherwise the receipt stays local. `found` records
+an href occurrence in built HTML; `exists` records the destination file check.
+Both must be true. The generated review HTML is separate from the four handoffs.


### PR DESCRIPTION
Part of #81. Devon accepted the vision and mission on 2026-09-08 (#2). This lands the engine-side alignment the review asked for.

**README.** First screen rewritten to the writing outcome with three next actions; a short Vision and mission section; the CLI and skills sections lead with what they do for the author; "What it is not" becomes "Files and publishing" and states the visibility and handoff rules; "Where this is going" is the current state plus the three proofs still owed. `package.json` description matches.

**Skills.**
- Wikilinks carry the target title verbatim, no display text: taught in `WRITING.md` Notes → Linking and in `commune-write`'s rules. `check` already reports it as `noncanonical-title` (verified on a scratch copy of the fixture vault), so #74 closes with this.
- One publication policy in two keys: `dumps.publish: never | opt-in | all` (whether dumps become pages; default opt-in, private unless a dump says `visibility: public`) and `dumps.commit: true | false` (whether the four handoffs are committed; default true). Setup asks both once; ship obeys the second.
- `commune-ship` step 5 requires the destination file under `dist/` for every new href and its `.md` twin, not only an occurrence of the href.
- The connect baseline records finding identities `(rule, file, target)`; write and ship compare identities as sets, since equal counts can hide a replaced finding.
- All three `references/handoffs.md` copies and all four `preflight.mjs` copies stay byte-identical; the skills suite checks it.

Docs and skills only; nothing in the npm tarball changes except README.md and the package description. `docs/plans/`, `docs/adr/`, `docs/research/` and `CHANGELOG.md` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1XXFXAsDP1ftHkaRbgwwz