### PR TITLE
docs(#84): adoption research and three commune.md concepts

### DIFF
--- a/docs/research/2026-09-08-commune-adoption/EXPANSION-RESEARCH.md
+++ b/docs/research/2026-09-08-commune-adoption/EXPANSION-RESEARCH.md
@@ -1,0 +1,70 @@
+# Expansion research
+
+Research completed 2026-09-08. All sources below are primary sources. Public actions were not taken. Counts reflect fetched snapshots rather than live measurements.
+
+## Astro integration catalog
+
+The catalog automatically refreshes weekly from npm packages with at least one of `astro-component`, `astro-integration`, or `withastro` in package keywords. It reads package name, description, repository, and homepage. Category keywords include `astro-loader` for Content Loaders and `tooling`, `utils`, or `utility` for Utilities. There is no separate initial submission form in this documented route. Publication to npm with suitable metadata is the route. Source [Astro integration publishing documentation](https://docs.astro.build/en/guides/integrations/) · read 2026-09-08.
+
+The `astro-integration` keyword also enables `astro add`. This assumes the integration is a default export and a function. Adding the keyword alone to an unsuitable package is insufficient. Source [Astro Integration API](https://docs.astro.build/en/reference/integrations-reference/) · read 2026-09-08.
+
+Inference for Commune based on the main agent's repository inspection that these keywords already exist. Check whether the current npm package is already discoverable before describing catalog inclusion as a future manual submission. A portable starter is a separate adoption asset and should use the public package rather than the repository fixture's relative file dependency.
+
+## Astro showcase
+
+The official showcase explicitly welcomes site submissions. The [submission route](https://astro.build/showcase/submit) · read 2026-09-08 redirects to the [Companies and Websites Using Astro discussion](https://github.com/withastro/roadmap/discussions/521) · read 2026-09-08. The discussion asks people using Astro to share their URL. It still has submissions dated September 2026. Source [Astro showcase](https://astro.build/showcase/) · read 2026-09-08.
+
+Concrete payload is a working Astro site's public URL and a short explanation of what the site does. The URL is the stated requirement. The short explanation is a recommendation inferred from examples, not a published mandatory field. No acceptance timeline or automatic inclusion promise was found. Commune's actual public demo or finished site is the relevant object, rather than an npm package listing.
+
+## Digital garden lists
+
+[kyrose awesome-digital-gardens](https://github.com/kyrose/awesome-digital-gardens) · read 2026-09-08 has a Gardening tools section including open-source software and an In development subsection. The fetched repository contains only a README and has 187 labeled stars. No CONTRIBUTING file or formal acceptance criteria were published in the fetched file listing. The [pull request route](https://github.com/kyrose/awesome-digital-gardens/pulls) · linked from repository read 2026-09-08 is the concrete route for proposing a README addition. Treat acceptance and response time as unknown. Tool-section fit is an inference from existing entries, not a maintainer endorsement.
+
+[best-of-digital-gardens](https://github.com/lyz-code/best-of-digital-gardens) · read 2026-09-08 invites issues, pull requests, and direct edits to `projects.yaml`. Its stated scope is actual digital gardens and second brains with published source content. The configuration currently allows all licenses, does not require a license or repository, and has no minimum star threshold. Entries include name, homepage, labels, GitHub identifier, description, and language category. Source [projects.yaml](https://raw.githubusercontent.com/lyz-code/best-of-digital-gardens/main/projects.yaml) · read 2026-09-08. Because the README scope and permissive configuration differ, a public garden built with Commune fits more clearly than submitting the publishing engine itself. The [contribution file](https://github.com/lyz-code/best-of-digital-gardens/blob/main/CONTRIBUTING.md) · attempted 2026-09-08 did not yield readable contribution instructions, so no additional requirements are claimed.
+
+[Maggie Appleton digital-gardeners pull requests](https://github.com/MaggieAppleton/digital-gardeners/pulls) · read 2026-09-08 includes open resource submissions and a June 2026 garden submission, alongside older pending requests. This establishes an available proposal route, not prompt review or likely acceptance. No submission was made.
+
+## Product Hunt
+
+The [new product submission route](https://www.producthunt.com/posts/new) · read 2026-09-08 redirects to login. Makers use a personal account, then Submit and New Product. Self-hunting is allowed and encouraged. The official preparation guide says new accounts must wait one week before posting. Paying hunters or promoters violates the guidance. Source [Before launch](https://www.producthunt.com/launch/before-launch) · read 2026-09-08.
+
+Prepare a direct product URL without shortened links or UTM parameters, product name without a descriptive slogan, tagline up to 60 characters, description up to 500 characters, up to three launch tags, and a square thumbnail. The recommended thumbnail is 240 by 240 pixels. A personal maker comment is strongly recommended and can ask for feedback, never upvotes. A GitHub repository can be the product URL. Source [Preparing for launch](https://www.producthunt.com/launch/preparing-for-launch) · read 2026-09-08.
+
+Live products are the current featuring requirement. Usefulness, novelty, craft, and creativity are evaluation dimensions, with no guarantee of homepage placement. Source [Featuring Guidelines](https://help.producthunt.com/en/articles/9883485-product-hunt-featuring-guidelines) · read 2026-09-08. A product offering only email signup is not homepage eligible. Source [Unreleased products](https://help.producthunt.com/en/articles/484932-can-i-submit-an-unreleased-product) · read 2026-09-08.
+
+Submission now ends with Schedule or Create Draft. A draft can be shared with fellow makers without selecting a date and is not indexed. Source [Create Draft change](https://help.producthunt.com/en/articles/9823193-where-did-launch-now-go) · read 2026-09-08. The changelog says scheduled launches automatically go live at midnight Pacific with no time selector. This is more operationally specific than the older launch guide's advice to aim for 12.01 am. Source [Product Hunt changelog](https://www.producthunt.com/changes) · read 2026-09-08.
+
+Repeat launches normally require six months and a significant change. Earlier relaunches require a request explaining the change. A new UI or price change alone is insufficient. Products on the same root domain also face the six-month submission gap. Source [Relaunch policy](https://help.producthunt.com/en/articles/484934-can-i-relaunch-my-product) · read 2026-09-08.
+
+## X
+
+The published rule is against bulk, duplicative, irrelevant, or unsolicited content that disrupts the service. It specifically forbids irrelevant promotional replies, aggressive unsolicited mentions, repeated identical posts, and link-only activity comprising most posts. Engagement manipulation is also prohibited. Source [X Authenticity policy](https://help.x.com/en/rules-and-policies/authenticity) · read 2026-09-08.
+
+There is no blanket ban on a maker describing their own product in an original post in these rules. This is an inference from the scope of prohibited conduct, not a separate self-promotion exception. Use a useful original demonstration and relevant conversation. Automated keyword-triggered unsolicited replies are explicitly disallowed. Source [X automation rules](https://help.x.com/en/rules-and-policies/x-automation?lang=browser) · read 2026-09-08.
+
+## Hacker News repeats and timing
+
+The FAQ permits a small number of reposts if a story has not had significant attention in roughly the last year. It prohibits deleting and reposting. This is not a promise that a weekly repeat launch is acceptable. Source [HN FAQ](https://news.ycombinator.com/newsfaq.html) · read 2026-09-08.
+
+Show HN says routine features and version updates generally are not substantive enough for another Show HN, while a major overhaul is probably acceptable. Users must be able to try the work. Landing pages and signup pages are not Show HN material. Source [Show HN Guidelines](https://news.ycombinator.com/showhn.html) · read 2026-09-08.
+
+No preferred Tuesday or specific launch hour appears in the HN FAQ, general guidelines, or Show HN guidelines reviewed. Any such schedule should be identified as an experiment based on Devon's availability, not a documented HN best practice. General rules prohibit generated or AI-edited text and soliciting upvotes or comments. Source [HN Guidelines](https://news.ycombinator.com/newsguidelines.html) · read 2026-09-08.
+
+## Earlier community research retained
+
+- r/ObsidianMD own rules say “If you are just here to advertise your product, don’t.” AI-generated content is removed. First-and-only promotional project posts face an immediate ban. AI workflow posts need the AI flair. Source [community rules sidebar](https://www.reddit.com/r/ObsidianMD/) · read 2026-09-08.
+- r/PKMS own rules say “Self promotion must go in the self-promotion thread”. AI-created posts are removed. Source [community rules sidebar](https://www.reddit.com/r/PKMS/) · read 2026-09-08. The [September promotion thread](https://old.reddit.com/r/PKMS/comments/1w4vx4h/self_promotion_thread_september_2026/) · posted 2026-09-02 · read 2026-09-08 says “If you are posting about something you made and are looking to promote it, please put it in the comments of this thread.” Its old Reddit sidebar displayed 77,965 readers.
+- r/Zettelkasten prohibits excessive self-promotion, link dumps, crossposting or mirroring, and AI-generated content. Source [community rules sidebar](https://www.reddit.com/r/Zettelkasten/) · read 2026-09-08. [September promotions](https://www.reddit.com/r/Zettelkasten/comments/1w4qtpg/sep_2026_selfpromotions_tools_books_and_courses/) · posted 2026-09-01 · read 2026-09-08 directs all promotion into that thread. Own membership was not verified.
+- r/DigitalGardens publishes one local rule, “Read the Reddiquette”. No separate self-promotion or AI-content restriction was published in the fetched sidebar. Absence is not affirmative permission. Source [own community sidebar](https://www.reddit.com/r/DigitalGardens/) · read 2026-09-08. Its 8,128-member figure is explicitly labeled in the [Zettelkasten related-community list](https://www.reddit.com/r/Zettelkasten/) · read 2026-09-08. That list also labels ObsidianMD at 358,164 members.
+- r/selfhosted requires production-ready promoted apps with documentation. New projects under three months belong only in its current New Project Megathread. Wednesdays allow suitably flaired tools helping selfhosters even when not selfhosted themselves. Source [own rules wiki](https://old.reddit.com/r/selfhosted/wiki/rules) · read 2026-09-08. The [community sidebar](https://old.reddit.com/r/selfhosted/) · read 2026-09-08 displayed 833,252 readers.
+
+## Earlier dated discussion evidence retained
+
+- [Karpathy's LLM Wiki setup](https://www.reddit.com/r/ObsidianMD/comments/1uai1w2/karpathys_llm_wiki_setup/) · posted 2026-06-20 · read 2026-09-08. A 145-vote fetched post had a 213-vote response questioning whether outsourcing linking improves human thinking. Other replies distinguish reference and AI memory from learning, and discuss preserving original files.
+- [LLM Wiki plugin](https://www.reddit.com/r/ObsidianMD/comments/1shntdn/new_plugin_llm_wiki_turn_your_vault_into_a/) · posted 2026-04-10 · read 2026-09-08. The 212-vote fetched post presents local Ollama processing and answers with source-note links. This shows topical interest, not automatic acceptance for another launch.
+- [Karpathy's workflow](https://www.reddit.com/r/ObsidianMD/comments/1sb02pb/karpathys_workflow/) · posted 2026-04-03 · read 2026-09-08. The 209-vote fetched post discusses retrieval and avoiding delegation of understanding.
+- [How do you guys manage AI memory/context](https://old.reddit.com/r/PKMS/comments/1w4rav6/how_do_you_guys_manage_ai_memorycontext/) · posted 2026-09-01 · read 2026-09-08. The poster loses old context across ChatGPT and Claude. Replies propose a user-owned Markdown context file. Twenty comments and score zero in the fetched snapshot. A specific need, not proof of wide demand.
+- [Combating AI Slop and Astroturfing](https://old.reddit.com/r/PKMS/comments/1vl25qk/combating_ai_slop_and_astroturfing/) · August 2026, exact day not verified · read 2026-09-08. Moderator statement says “All promotions should go in the Promotions thread.” Repeated AI-content violations lead to bans.
+- [Selfhosted Quarter 2 Update](https://old.reddit.com/r/selfhosted/comments/1sey9ch/quarter_2_update_revisiting_rules_again/) · posted 2026-04-07 · read 2026-09-08. Moderator announcement introduces the project megathread and a bot requiring a reply explaining AI involvement before approval. The fetched discussion had 372 comments.
+
+Dedicated about/rules URLs were opened for the five communities. Three rendered empty rules shells and two failed. The community-owned sidebars and selfhosted wiki supplied the rules recorded here. No unlabeled activity figures were treated as membership counts.

--- a/docs/research/2026-09-08-commune-adoption/OUTPUT.md
+++ b/docs/research/2026-09-08-commune-adoption/OUTPUT.md
@@ -1,0 +1,198 @@
+# A roadmap from six stars to people maintaining their own wikis
+
+Build commune.md as the front door, ship a portable starter, and recruit the first outside authors through Astro. Earn wider distribution with their working wikis and second edits. Treat stars and use as separate outcomes.
+
+The starting snapshot is 6 stars, 1 fork and npm 0.5.2. Fifty total needs 44 net additions, but issue 84 requires 50 stars from strangers, an install issue from a stranger and a submitted Greptile application. Count qualifying existing stars separately. Every public step is Devon’s. Preserve the rule against sockpuppets, bots and asking friends for stars. [Facts](repo-facts.txt) and [issue 84](ISSUE-84.md), read 2026-09-08.
+
+Grok’s strongest suggestions are a starter, a visible demonstration and clearer audience selection. Its numerical star forecasts, universal posting time and ranking claims are unproven. GitHub traffic cannot tell us why someone left. The detailed evidence and corrections are in [RESEARCH.md](RESEARCH.md), read 2026-09-08. Community rules and distribution research are also recorded in [EXPANSION-RESEARCH.md](EXPANSION-RESEARCH.md), read 2026-09-08.
+
+## The people, ranked
+
+These profiles are hypotheses from recent discussions, not measured conversion segments.
+
+1. **Astro builders with markdown notes.** Use Astro, Git and an editor, sometimes Obsidian. Want connected publishing without assembling everything. First ten minutes should produce two linked notes. Highest install fit because the required stack is familiar. April’s discussion asks for simpler content maintenance. August’s roundup lists related-content, markdown and vault integrations. [Astro discussion](https://www.reddit.com/r/astrojs/comments/1sn4wht/astropress/), posted 2026-04-16, read 2026-09-08. [August roundup](https://astro.build/blog/whats-new-august-2026/), August 2026, read 2026-09-08.
+
+2. **Gardeners who want their site to feel personal.** Use Obsidian’s Digital Garden plugin or consider Quartz. Complain about limited customization and setup complexity. First ten minutes should test three links and return navigation in the panes. Strong reader fit, narrower installer fit. [Garden discussion](https://www.reddit.com/r/DigitalGardens/comments/1t7qh1n/taking_a_different_approach/), posted 2026-05-09, read 2026-09-08.
+
+3. **Claude users with unfinished writing.** Use Claude Code, markdown and perhaps Obsidian. Want clean takeaways after messy exploration. First ten minutes on a prepared wiki should turn a paragraph into connection candidates and an interview. Good skills testers after the installed loop is proven. [Canvas discussion](https://www.reddit.com/r/ClaudeAI/comments/1us2mxw/i_built_a_canvas_frontend_for_claude_on_the_agent/), posted 2026-07-09, read 2026-09-08.
+
+4. **People carrying context between tools.** Use ChatGPT, Claude and local files. Complain about copying context and losing earlier decisions. First ten minutes should identify one unreferenced note through the CLI. Medium fit because Commune currently indexes its publishing corpus. [PKMS discussion](https://old.reddit.com/r/PKMS/comments/1w4rav6/how_do_you_guys_manage_ai_memorycontext/), posted 2026-09-01, read 2026-09-08. [README][repo], read 2026-09-08.
+
+## The places
+
+Order is launch priority. Go means the proposed shape fits the rules read after the install gate. ND means no best day or hour was documented on the cited page. Publication days are not submission deadlines. Sizes are published snapshots, not live counts. Unverified means no clearly labelled count was retrieved.
+
+| Place and rules | Size | Exact rule or invitation, read 2026-09-08 | Shape and time | Decision |
+| --- | --- | --- | --- | --- |
+| [r/astrojs](https://www.reddit.com/r/astrojs/), read 2026-09-08 | Unverified | “Sharing helpful resources is welcome, but don't spam or constantly self-promote.” | Weekly showoff comment, ND | Go first with two-note build ask. |
+| [r/DigitalGardens](https://www.reddit.com/r/DigitalGardens/), read 2026-09-08 | Unverified | “Read the Reddiquette” is the only published local rule | Garden tour and reading question, ND | Go once as disclosed maker. No specific promotion clause was found. |
+| [r/ClaudeAI](https://www.reddit.com/r/ClaudeAI/), read 2026-09-08 | Unverified | “project must be free to try and say so” | Built with Claude, ND | Go after skills proof. Explain Claude’s role. Feed requires OP karma above 100. |
+| [Astro Weekly](https://newsletter.astroweekly.dev/p/astro-weekly-144), read 2026-09-08 | 1000+ | “Have a link to share? Drop me an email” | Editorial submission. Sunday publication | Go. Independent of Astro’s official monthly roundup. |
+| [Show HN](https://news.ycombinator.com/showhn.html), read 2026-09-08 | Unverified | “Please don't ask friends to upvote or comment.” | Runnable Show HN, ND | Go with Devon-written prose. [HN guidelines](https://news.ycombinator.com/newsguidelines.html), read 2026-09-08, prohibit generated or AI-edited text. |
+| [This Week in Obsidian](https://raw.githubusercontent.com/z08io/this-week-in-obsidian/main/README.md), read 2026-09-08 | Unverified | “Submit an issue” | Content suggestion. Tuesday publication | Go after an Obsidian round trip. Declare affiliation in the form. |
+| [r/PKMS](https://www.reddit.com/r/PKMS/), read 2026-09-08 | [77,930](https://old.reddit.com/r/PKMS/), read 2026-09-08 | “Self promotion must go in the self-promotion thread” | Monthly thread, ND | Go with Devon-written comment. AI-created posts are removed. |
+| [r/ObsidianMD](https://www.reddit.com/r/ObsidianMD/), read 2026-09-08 | Unverified | “If you are just here to advertise your product, don’t.” | Original workflow discussion, ND | No cold launch. AI-generated content is prohibited. |
+| [r/Zettelkasten](https://www.reddit.com/r/Zettelkasten/), read 2026-09-08 | Unverified | “Do not engage in excessive self-promotion.” | Monthly promotions thread, ND | Defer until revision evidence. “If you didn't write it yourself, don't post it.” |
+| [r/selfhosted](https://old.reddit.com/r/selfhosted/wiki/rules), read 2026-09-08 | [833,252](https://old.reddit.com/r/selfhosted/), read 2026-09-08 | “Promoted apps must be production ready and have docs.” | Hosting walkthrough. Wednesday exception for adjacent tools | Defer until hosting proof. Projects under three months use New Project Megathread. |
+| [r/opensource](https://www.reddit.com/r/opensource/), read 2026-09-08 | Unverified | “No Spam or Excessive Self-Promotion” | Devon-written project explanation, ND | Defer. All AI-generated content is considered low effort and ban worthy. |
+| [r/SideProject](https://old.reddit.com/r/SideProject/), read 2026-09-08 | 813,787 | “a subreddit for sharing and receiving constructive feedback on side projects” | Project name and short description, ND | Reserve. Weak evidence of qualified publishers. |
+| [Astro Discord](https://astro.build/chat), attempted 2026-09-08 | Unverified | Rules channel unavailable. Official [roundup](https://astro.build/blog/whats-new-august-2026/), read 2026-09-08, invites `#showcase` submissions | Showcase, ND | Hold until in-server rules are read. |
+
+## The angles, ranked
+
+1. **My working wiki became a package.** Show the panes and the writing they connect. Profiles 1 and 2 want something they can shape. The brief reports devon.md as the only consumer with zero copies. Verify dependency and imports before making that a launch claim. [Brief](BRIEF.md), read 2026-09-08.
+
+2. **Find connections before building the site.** Profiles 3 and 4 can run `commune graph related` on a draft and `commune graph query --unreferenced --json` on sample notes. This is the strongest technical demonstration of maintenance. The CLI reads disk without an Astro process. [README][repo], read 2026-09-08.
+
+3. **Published notes have markdown twins.** Useful immediately for profiles 1 and 3. `/notes/hello/` maps to `/notes/hello.md`. Handwritten routes are excluded. [README][repo], read 2026-09-08. Astro Weekly already featured `.md` siblings on May 17, so avoid a novelty claim. [Issue 131](https://newsletter.astroweekly.dev/p/astro-weekly-131), read 2026-09-08. HN’s June 5 debate disputes automatic `llms.txt` consumption. Promise a fetchable source, without search-ranking claims. [Discussion](https://news.ycombinator.com/item?id=48410783), read 2026-09-08 via API.
+
+4. **Build and CLI share the resolver.** Good supporting reason for profile 1. Shared code removes one source of drift. It cannot guarantee links never break. The apostrophe fix shipped September 7. Direct demand for one resolver was not established in the sampled discussions. [README][repo] and [CHANGELOG][changes], read 2026-09-08.
+
+5. **Dictation reaches a note through questions and review.** Profile 3 can inspect the preserved dump, suggested connections, interview and side-by-side draft. Four skills shipped September 4, but the installed loop remains unverified even on the first wiki. [README][repo] and [CHANGELOG][changes], read 2026-09-08.
+
+6. **Find the assumptions that only fit my wiki.** Use the missing second consumer as an invitation to test. It is an ask, not independent demand evidence. HN’s April 23 debate about single-maintainer notes tools supports showing continued use and fixes. [Discussion](https://news.ycombinator.com/item?id=47883025), read 2026-09-08 via API. [README][repo], read 2026-09-08.
+
+## What must exist first
+
+1. A portable starter using the published npm package, three public notes, an update, working panes, backlinks and checks. The existing fixture uses `file:../../..`, so copying it alone is insufficient. [Fixture manifest][fixture], read 2026-09-08.
+2. A timed install on a machine that is not Devon’s, using public instructions. Record OS, versions, elapsed time and resulting page. Nothing goes out until two linked notes build within ten minutes. [Issue 84](ISSUE-84.md), read 2026-09-08.
+3. A check of public, private and draft samples. Notes are filtered by visibility. Research, pages and updates are included regardless. [README][repo], read 2026-09-08.
+4. A 20 second recording of two panes, return navigation, one graph command and a markdown twin. Use the observed [Commune source URL](https://devon.md/notes/what-is-commune.md), read 2026-09-08.
+5. A pinned **Tell me where it broke** issue. Ask for channel, OS, Node and package versions, minutes, attempted step, expected result and actual result. Accept comments and split bugs afterward.
+6. A recorded installed-skills run before the Claude post. A dependency/import check before the zero-copies claim. A short README opening with audience, demo, starter, prerequisites and feedback.
+
+## commune.md
+
+Make commune.md the second package consumer and the simplest example someone can copy. Keep devon.md as the personal proof. Publish the site’s source and import the package without copying engine code. This is proposed work, not an existing site.
+
+The first screen should say **Keep your thinking connected** and explain that Commune turns markdown notes and rough thoughts into a personal wiki people can maintain and publish. Follow with the recording, **Try the starter**, **Explore a wiki**, and a quieter GitHub link. Put the star action after a useful demonstration.
+
+Build five routes initially. Home explains the job. Start gives a measured path with expected output. Demo lets readers follow three notes and their markdown sources. Writing shows one dump, interview, revision and review. Docs covers integration, links, visibility, hosting and troubleshooting. Generate shared installation text from one source so README and site instructions stay aligned.
+
+Add a dated status block naming what works and what remains unproven. Later add Showcases when outside authors consent to inclusion. Add Questions and Show your wiki Discussions when Devon can maintain them. Start with the pinned issue to avoid splitting early feedback across empty rooms.
+
+## The ask per channel
+
+| Channel | One ten minute task |
+| --- | --- |
+| Astro Reddit, Discord, Weekly, Show HN | Build two linked public notes from the portable starter and report the first confusing step. |
+| DigitalGardens, SideProject | Follow three links on devon.md, return to the first note and describe where the panes helped or lost you. |
+| ClaudeAI | On a prepared wiki, capture a paragraph and reach the interview. Report one useful connection or bad assumption. |
+| PKMS | Find one unreferenced note and explain whether the result makes sense. |
+| ObsidianMD, its roundup | Open the starter as a vault, edit a note and rebuild. Report the first link mismatch. |
+| Zettelkasten | Compare an original and revised note. Identify one stronger or weaker connection. |
+| selfhosted, opensource | Serve the static build and open a note, backlink and markdown twin. Report the first failure. |
+
+Accept replies in the originating thread. Keep reproducible install evidence in the pinned issue. These are proposed timeboxes, not completed tests.
+
+## Four drafts
+
+Draft facts and voice come from [README][repo], [voice export](voice-export.md) and [brief](BRIEF.md), read 2026-09-08. Use after the gates pass. The starter must be publicly available first. [Tell me where it broke](https://github.com/dmthepm/commune-wiki/issues/85), read 2026-09-08, already exists and is pinned. The demonstrated [home page](https://devon.md), read 2026-09-08, matches the supplied home note.
+
+### Astro weekly showoff
+
+**Title** My notes became an Astro integration
+
+**Alternative** I pulled the wiki engine out of my personal site
+
+I built my own wiki first. Then I pulled its tools into Commune so someone else could use them.
+
+It publishes markdown notes with wikilinks through Astro. The build and CLI share a link resolver. I can check connections while I write, and published notes get a markdown twin.
+
+My site is devon.md. Commune is MIT licensed. The package is @dmthepm/commune.
+
+If you have ten minutes, try the starter linked from the README. Add two public notes, link one to the other and build. Tell me the first step where you had to guess.
+
+The repo is github.com/dmthepm/commune-wiki. Reply here or use the pinned issue called Tell me where it broke.
+
+### DigitalGardens
+
+**Title** Do the panes help you follow a thought
+
+**Alternative** My working notes have become a wiki I can keep changing
+
+I walk and talk into my phone a lot. For a long time, my ideas were buried in random notes. I’ve been giving them a place I can come back to and change.
+
+That place is devon.md. The sliding panes owe a debt to Andy Matuschak’s notes. I like following a link while keeping the thought I came from beside it.
+
+I also built Commune, the open source package behind the site.
+
+I’d like to know how it feels to someone who doesn’t already know the notes. Give it ten minutes. Follow three links, then get back to where you started. Where did the panes help, and where did they get in the way?
+
+Reply with the path you took and the device you used.
+
+### ClaudeAI
+
+**Title** I made Claude Code skills for turning a dictated thought into a connected note
+
+**Alternative** I want to test my note-writing skills on someone else’s wiki
+
+I walk and talk into my phone a lot. I’m building Commune to help turn those thoughts into notes I can keep working on.
+
+I made four skills for Claude Code and Codex. They save the dump, find connections, ask a short round of questions and show the original and draft side by side. Claude does the questioning and drafting through the skills. I decide what the note says. Shipping opens a PR for review.
+
+The code is MIT and free to try with your existing agent access. I’m looking for the assumptions that only fit my wiki.
+
+If you have a prepared Commune wiki, give it ten minutes. Capture one paragraph and reach the interview. Tell me one useful connection or one question that missed the point.
+
+Setup is at github.com/dmthepm/commune-wiki. Reply here or use Tell me where it broke in the pinned issues.
+
+### Astro Weekly submission
+
+**Title** Commune turns linked markdown notes into an Astro wiki
+
+**Alternative** The package behind my working notes
+
+Hi Nathan,
+
+I built devon.md for my own working notes, then extracted its tools into Commune. It’s a personal MIT project.
+
+The Astro integration and CLI share a link graph. I can inspect connections without building the site, then publish notes with backlinks and markdown twins. The package ships the components behind my sliding panes too.
+
+I thought it might fit Astro Weekly. I’m trying to find the next person who wants to make a wiki with it.
+
+The starter and code are at github.com/dmthepm/commune-wiki. If you have ten minutes, try adding two linked notes and tell me the first step that needs a better explanation.
+
+Devon
+
+For HN, PKMS, ObsidianMD, Zettelkasten and opensource, Devon writes the post himself under the cited rules. HN’s outline is origin, runnable starter, shared graph, markdown endpoint, missing outside proof. Begin the title with Show HN.
+
+## Thirty days
+
+**September 8–14.** Build the starter and commune.md minimum, prove the gates, then post once in Astro’s current showoff thread and DigitalGardens. Record baseline metrics. Aim for three reported outside attempts. Shift dates if the gate slips.
+
+**September 15–21.** Fix the largest install failure. Submit to Astro Weekly. Post the recorded Claude workflow if the run and account requirements pass. Devon may write a PKMS promotion-thread comment. Aim for five completed installs cumulatively and one stranger’s issue.
+
+**September 22–28.** Ask willing testers in existing threads about their second edit. Publish the strongest fix and revised instructions. Submit Devon’s Show HN. Send the Obsidian roundup suggestion after the vault round trip works.
+
+**September 29–October 7.** Follow the channel producing completed installs. Add Discord after reading its rules. Publish a second-consumer case study only if it exists. Assess the 50-star issue and Greptile application. Targets are planning choices, not forecasts.
+
+If a moderator removes a post or says promotion is unwelcome, stop that channel. Do not repost or switch accounts. Answer substantive criticism, fix what is warranted and stop arguing. If ten reported attempts yield fewer than three completions, pause new distribution and repair onboarding.
+
+## Beyond fifty
+
+Budget eight hours a week as a working assumption. Spend three on onboarding and defects, two helping users, two on one useful public artifact, and one on measurement. The next stage opens when the evidence supports it.
+
+| Stage | Target outcomes | Work that earns the next stage |
+| --- | --- | --- |
+| Days 1–30 | 50 qualifying stars, 5 activated authors, 2 second editors | Starter, site, first outside reports and fixes |
+| Days 31–60 | 100 total stars, 20 activated authors, 8 returning authors | Two permissioned case studies, troubleshooting, one proven install path, official Astro discovery submissions |
+| Days 61–90 | 200 stars, 50 activated authors, 20 returning authors | Weekly practical tutorials, accepted directory submissions, repeated writing-loop evidence, contributor documentation |
+| Months 4–6 | 300–500 stars, 150 activated authors, 60 monthly active authors | Three reliable acquisition routes, tested upgrades, more outside showcases, help from repeat contributors |
+| Months 7–12 | 500+ stars, 600 activated authors, 300 monthly active authors | Replicate the best route, deepen Obsidian and agent workflows based on reports, maintain support and upgrade capacity |
+
+These are aspirations. Hundreds of active authors require retention, not just launch reach. Define activated as an outside person building and editing their own wiki. Define returning as another edit after seven days. Define monthly active as an author reporting an edit or publish in the last 30 days. Count through voluntary receipts and sample follow-ups. Do not infer private use from downloads.
+
+For planning only, 6,000 qualified starter visits at 10% activation and 50% subsequent monthly activity would yield 600 activated and 300 active authors. Neither rate is measured. Replace them after the first cohort. Stars get a separate ledger. Save GitHub traffic weekly because its window is 14 days. [GitHub traffic documentation](https://docs.github.com/en/repositories/viewing-activity-and-data-for-your-repository/viewing-traffic-to-a-repository), read 2026-09-08.
+
+Use one practical article per week, one recorded fix, opt-in outside showcases and ecosystem submissions. Ask relevant strangers to test only where they invite suggestions. Never ask them to star. Keep a small, explicit backlog of reproducible bugs and requested examples. If returning use stalls for two cohorts, spend the next cycle on editing and upgrades rather than more channels.
+
+## Three uncertainties
+
+1. **Can an outside person finish in ten minutes?** Settle with the public starter instructions followed on another machine and a recorded timer. [Current fixture manifest][fixture], read 2026-09-08, explains why that proof is still missing.
+2. **Which route produces returning authors?** Settle with the proposed cohort ledger after two seven-day follow-ups. No present source establishes channel conversion rates.
+3. **Who on X explicitly wants this workflow?** The requested Grok query should supply original URLs, dates, pain statements and invitations to suggest tools. Verify those posts before ranking outreach. Do not use an unverified follower count as expected reach.
+
+[repo]: ../../../README.md
+[changes]: ../../../CHANGELOG.md
+[fixture]: ../../../tests/fixtures/consumer/package.json

--- a/docs/research/2026-09-08-commune-adoption/RESEARCH.md
+++ b/docs/research/2026-09-08-commune-adoption/RESEARCH.md
@@ -1,0 +1,144 @@
+# What would make someone keep using Commune
+
+Research date 2026-09-08. This file records evidence for the adoption roadmap and can be adapted into a research page on devon.md. The shorter companion is DEVON-NOTE.md. Neither has been published.
+
+## The finding
+
+Commune has a plausible first audience among Astro builders who already keep markdown notes. The immediate job is publishing and maintaining connected writing. The most promising demonstration joins three things a visitor can inspect, a note in the browser, the same note as markdown, and the graph answering a question before a build.
+
+That is an inference from the discussions below. It is not evidence that visitors will install, star the repository or keep writing. The first independent install and second edit are the tests of that inference.
+
+## What we checked
+
+We read the supplied issue, current README and changelog, Devon’s home note and writing rules, prior positioning research and supplied repository facts. We then read community-owned rules and discussion pages, newsletter issues, official distribution instructions and GitHub documentation.
+
+The discussion window is March 8 through September 8, 2026. A thread’s publication date is distinct from the date we read it. Reddit and search results sometimes contain cached snapshots. We do not treat vote counts as current measures or as evidence of conversion. For HN items whose web pages failed to load, the HN Algolia item API supplied their dated text and replies.
+
+The strongest dated coverage is Astro, DigitalGardens, ClaudeAI, ObsidianMD, PKMS and HN. We found no sufficiently specific dated demand thread for SideProject. The opensource sample was weak. Astro Discord’s public invite did not expose its rules or discussion history. X audience research is pending the optional Grok query. These are gaps in coverage, not findings of absent demand.
+
+## Repository evidence
+
+| Fact | Source and date read | Implication |
+| --- | --- | --- |
+| Six stars, one fork, npm 0.5.2 | [Supplied snapshot](repo-facts.txt), read 2026-09-08 | Use as the baseline. Count future stars separately from authors. |
+| Description and topics already describe the engine, graph, skills and devon.md. Discussions are disabled | [Repository API](https://api.github.com/repos/dmthepm/commune-wiki), read 2026-09-08 | Do not spend a launch cycle fixing metadata that already exists. Record the fetched values below. |
+| Astro integration, CLI and optional skills are distinct install paths | [README][repo], read 2026-09-08 | A skills install alone is not a new wiki. |
+| Astro 7 and Node 22.12+ are required | [README][repo], read 2026-09-08 | Show prerequisites before starting the timer. |
+| Minimal install route is plain markup. Components require further integration | [README][repo], read 2026-09-08 | Do not imply the three-file example produces devon.md’s panes. |
+| Fixture depends on `file:../../..` | [Fixture package file][fixture], read 2026-09-08 | It proves a boundary against the local working tree. It is not a portable npm starter. |
+| `astro-integration` and `withastro` are already package keywords | [Package file][package], read 2026-09-08 | Verify catalog discovery before adding a redundant submission task. |
+| Build and CLI use the exported graph library | [README][repo], read 2026-09-08 | Shared resolution is a concrete design feature. It does not prove bug-free resolution. |
+| Published content entries receive markdown twins. Handwritten routes do not | [README][repo], read 2026-09-08 | Avoid saying every possible site URL has a twin. |
+| Only public notes enter the graph. Research, pages and updates are included regardless of visibility | [README][repo], read 2026-09-08 | Do not advertise a private-vault index or arbitrary vault publishing without a separate test. |
+| Skills shipped September 4. Installed end-to-end use remains unverified | [CHANGELOG][changes] and [README][repo], read 2026-09-08 | Demonstrate the installed path before describing it as proven. |
+| Version 0.5.1 fixes apostrophe targets and 0.5.2 fixes wrapping | [CHANGELOG][changes], read 2026-09-08 | Prefer measured reliability language over links never drift. |
+| One consumer and zero copies are asserted in the supplied brief | [Brief](BRIEF.md), read 2026-09-08 | This session did not audit the consumer’s dependency tree and imports. Keep that check in the launch backlog. |
+
+The live API description was “A personal wiki engine for Astro with a link graph, a CLI that finds connections while you write, and agent skills that turn dictated dumps into maintained notes. MIT. It runs devon.md.” Topics were agent-skills, astro, claude-code, digital-garden, knowledge-management, markdown, obsidian, personal-knowledge-management, static-site-generator and wiki. The homepage was devon.md and Discussions were disabled. [Repository API](https://api.github.com/repos/dmthepm/commune-wiki), read 2026-09-08.
+
+The live [home page](https://devon.md), read 2026-09-08 through curl, matches the supplied working-notes voice. The linked [Commune markdown source](https://devon.md/notes/what-is-commune.md), read 2026-09-08 through curl, returns the source note. A guessed `/notes/commune.md` returned a missing-page document. That was a wrong guessed path, not evidence of a broken advertised link. Derive demonstration URLs from observed links.
+
+## What people were discussing
+
+**Customization and setup friction.** On May 9, a DigitalGardens author described starting with Obsidian’s Digital Garden plugin, feeling visually constrained and finding Quartz too complicated to set up. They built their own HTML site and later described reusable templates and a publishing plugin. The useful signal is a desire to control presentation while keeping an editing path. One post cannot establish broad dissatisfaction with Quartz. [Discussion](https://www.reddit.com/r/DigitalGardens/comments/1t7qh1n/taking_a_different_approach/), posted 2026-05-09, read 2026-09-08.
+
+**Some gardeners want less technical work.** A June Blogger garden received a July 3 comment from someone seeking a solution with less tinkering. A July 10 publishing question received a reply asking whether the author was comfortable with terminal commands, and the author was not. These are counterexamples to treating all gardeners as likely Astro installers. [Blogger garden](https://www.reddit.com/r/DigitalGardens/comments/1ucgflu/blogger_digital_garden/), posted 2026-06-22, read 2026-09-08. [Publishing question](https://www.reddit.com/r/DigitalGardens/comments/1usiaq6/ideas/), posted 2026-07-10, read 2026-09-08.
+
+**Astro builders discuss editing as well as hosting.** The April 16 AstroPress thread asks for a simpler complete experience for people accustomed to WordPress. Replies discuss headless CMSs, markdown and Obsidian. This supports serving the narrower developer who accepts files and code, while making the starter concrete. It does not show demand for another general CMS. [Discussion](https://www.reddit.com/r/astrojs/comments/1sn4wht/astropress/), posted 2026-04-16, read 2026-09-08.
+
+**Markdown siblings already have distribution.** Astro Weekly’s May 17 issue featured an Astro integration with per-page markdown siblings, an llms.txt index and content negotiation. Its August 16 issue covered turning Starlight documentation into agent skills. These demonstrate editorial interest and competing work. They argue for explaining Commune’s writing graph and actual consumer, without claiming markdown twins or skills are unique. [Issue 131](https://newsletter.astroweekly.dev/p/astro-weekly-131), posted 2026-05-17, read 2026-09-08. [Issue 144](https://newsletter.astroweekly.dev/p/astro-weekly-144), posted 2026-08-16, read 2026-09-08.
+
+**The official Astro ecosystem already has nearby tools.** August’s roundup lists `astro-content-links`, an Obsidiary vault integration, markdown-to-docs tools, an llms.txt helper and `starlight-to-skills`. A feature checklist alone will not distinguish Commune. The intended wedge is finding and checking connections while maintaining a personal wiki, with the same code used to publish. [Official August roundup](https://astro.build/blog/whats-new-august-2026/), August 2026, read 2026-09-08. Commune’s corresponding features are documented in [README][repo], read 2026-09-08.
+
+**Claude users want inspectable writing artifacts.** A July 9 canvas project keeps notes as markdown and discusses messy exploration followed by clean takeaways. A March 14 thread describes avoiding unnecessary Word document conversion when the useful output is markdown. These are experiences, not controlled benchmarks. [Canvas discussion](https://www.reddit.com/r/ClaudeAI/comments/1us2mxw/i_built_a_canvas_frontend_for_claude_on_the_agent/), posted 2026-07-09, read 2026-09-08. [Markdown discussion](https://www.reddit.com/r/ClaudeAI/comments/1rtpww1/stopped_asking_claude_for_word_docs_and_my/), posted 2026-03-14, read 2026-09-08.
+
+**Context maintenance is a stated problem.** A September 1 PKMS author describes losing earlier context and moving information between ChatGPT and Claude. Replies suggest durable markdown. The fetched thread had 20 comments and a score of zero. This is a specific pain statement with a small sample, not proof of broad popularity. [Discussion](https://old.reddit.com/r/PKMS/comments/1w4rav6/how_do_you_guys_manage_ai_memorycontext/), posted 2026-09-01, read 2026-09-08.
+
+**Obsidian discussion contains demand and resistance.** An April 10 LLM Wiki plugin post describes local processing and answers linked to source notes. A June 20 discussion questions whether outsourcing linking and refinement helps human understanding. Preserve originals and demonstrate the author’s decisions. Avoid promising that an agent can do the understanding for them. [Plugin discussion](https://www.reddit.com/r/ObsidianMD/comments/1shntdn/new_plugin_llm_wiki_turn_your_vault_into_a/), posted 2026-04-10, read 2026-09-08. [LLM wiki discussion](https://www.reddit.com/r/ObsidianMD/comments/1uai1w2/karpathys_llm_wiki_setup/), posted 2026-06-20, read 2026-09-08.
+
+**A current Obsidian roundup is available.** The July 21 This Week in Obsidian issue includes Digital Garden and Claudian. Its repository accepts content suggestions through issues. The form explicitly asks whether the submitter is affiliated. This gives a concrete editorial route after an Obsidian round trip is demonstrated. [Issue 31](https://thisweekinobsidian.substack.com/p/this-week-in-obsidian-31), posted 2026-07-21, read 2026-09-08. [Submission form source](https://github.com/boundless-forest/this-week-in-obsidian/blob/main/.github/ISSUE_TEMPLATE/content-suggestion.yml), read 2026-09-08 through GitHub API.
+
+**llms.txt discussion does not establish crawler adoption.** HN’s June 5 replies distinguish individual agents reading documentation from providers crawling sites. Some report useful requests and some report none. One commenter wants markdown without JavaScript bundles. Use a direct endpoint demonstration as evidence. Do not turn these anecdotes into a universal performance or discovery claim. [Discussion](https://news.ycombinator.com/item?id=48410783), posted 2026-06-05, read 2026-09-08 through [item API](https://hn.algolia.com/api/v1/items/48410783), read 2026-09-08.
+
+**Single-maintainer projects can attract skepticism and support.** The April 23 HN thread includes a harsh prediction of short project life and several replies defending individual builders. Quoting the hostile response alone would misrepresent the conversation. A working personal dependency and visible response to users address the concern more usefully than promising indefinite maintenance. [Discussion](https://news.ycombinator.com/item?id=47883025), posted 2026-04-23, read 2026-09-08 through [item API](https://hn.algolia.com/api/v1/items/47883025), read 2026-09-08.
+
+## How the rules change the plan
+
+HN, ObsidianMD, PKMS, Zettelkasten and opensource prohibit generated prose or AI-created content. Their public posts need Devon’s original writing, not this document’s paste-ready drafts. The top four drafts therefore serve Astro Reddit, DigitalGardens, ClaudeAI and Astro Weekly. Full quoted rules, URLs, reading dates and access gaps are retained in [OUTPUT.md](OUTPUT.md) and [EXPANSION-RESEARCH.md](EXPANSION-RESEARCH.md), read 2026-09-08.
+
+Do not read the DigitalGardens sidebar’s silence on promotion as a guarantee of acceptance. The recommended garden tour is a judgment based on the sidebar and comparable discussion. Do not infer Discord rules from Astro’s public showcase invitation. No current in-server rule was readable here.
+
+The old Obsidian Roundup introduction was written in 2021. We did not verify an active current submission route for that publication. This Week in Obsidian is a separate, current target, supported by the issue and form above. [Older introduction](https://forum.obsidian.md/t/obsidian-roundup-weekly-newsletter-for-tips-news-resources/17782), read 2026-09-08.
+
+## Assessing the Grok suggestions
+
+| Suggestion | Assessment | Action |
+| --- | --- | --- |
+| Starter before broad promotion | Supported by the local file dependency and current manual setup | Build a portable starter with published dependencies. |
+| A recording and clearer README | Reasonable test, no measured conversion uplift here | Show the outcome and record first-screen questions. |
+| commune.md | Strong proposed separation of product explanation and personal writing | Make it a public package consumer and source example. |
+| Discussions are off | Verified by repository API above | Enable when open-ended questions justify a second venue. |
+| 621 X followers and unused distribution | Not verified | Use Grok for original posts and relevant people, not assumed reach. |
+| Forty to eighty stars in one day | Unsupported forecast | Measure qualified attempts and completion. |
+| Tuesday morning ET is best | No official rule found | Post when Devon can respond. Treat time as an experiment. |
+| One Show HN ever | Incorrect as a blanket claim | Follow the repeat guidance in the expansion research. |
+| Friends for the first stars | Conflicts with issue 84 | Preserve the no-friend-star request rule. |
+| Add withastro and Astro keywords | Already present in package file | Check whether the catalog already lists it. |
+| GitHub traffic proves bounce reasons | Unsupported interpretation | Collect voluntary failure reports. |
+| Twenty messages yield fifteen to twenty-five stars | Unsupported conversion forecast | Use a small relevance-based outreach experiment only where welcome. |
+
+These judgments compare the supplied Grok text with the cited repository files and primary evidence. They do not assert that every tactic is ineffective.
+
+## Implementation order for commune.md and the starter
+
+This is a proposed backlog with acceptance criteria. Nothing in this section has been implemented during the research task.
+
+**P0 portable starter.** Copy the fixture’s useful structure into a separately usable starter, replace the local dependency with the tested npm release, and include three public notes and one update. Include the fuller pane interface, backlinks, markdown links and working check commands. Pin the initial versions used for the timed test. Document where content belongs and what public means. Success is a fresh download outside the source repository building without access to Devon’s files.
+
+**P0 first use.** Test on another machine with no inherited project settings or dependencies. Start from the public instructions. Record the exact steps, prerequisite time and project setup time separately. The ten minute path should start from its stated prerequisites. One participant choosing a folder, changing a note and following the built link provides stronger evidence than CI alone. Keep failed attempts too.
+
+**P0 product site.** Implement the five routes in OUTPUT.md. Use Commune as a dependency, make the site source public and keep sample content small enough to understand. Put the testable artifact in the hero. The primary action reaches the starter in one click. A visitor should be able to identify the audience, prerequisites and expected output without reading integration internals.
+
+**P0 visible state.** Show tested versions and the last verified install date. List the unproven skills loop until the installed path is tested. Use a real issue link only after it exists. Keep the live demonstration navigable without login.
+
+**P1 writing proof.** Record a short public dump, an interview answer, a note diff and the resulting links. Separate author decisions from agent suggestions. Confirm the installed skills follow the review boundary and create a PR without merging. This becomes the Claude demonstration and the Writing page.
+
+**P1 upgrades.** Before recruiting many authors, test an upgrade from the first starter version to the next release. Keep at least one older consumer fixture. Describe changed behavior and required actions. An author who can create a wiki but cannot maintain it has not received the mission’s promised outcome.
+
+**P1 feedback and measurement.** Start with one pinned failure issue. Later add Questions and Show your wiki Discussions with a short welcome. GitHub documents Discussions as a venue for open-ended questions and community conversation, while issues track scoped work. [GitHub guidance](https://docs.github.com/en/get-started/using-github/communicating-on-github), read 2026-09-08. The decision to stage these surfaces is a capacity judgment.
+
+**P2 discovery.** Verify the automatic integration listing. Submit the completed site to Astro’s showcase. Propose a concise tool entry to relevant lists after reading their current contribution instructions. Submit actual gardens to garden lists. Treat each acceptance as an editorial decision. The concrete routes are preserved in [EXPANSION-RESEARCH.md](EXPANSION-RESEARCH.md), read 2026-09-08.
+
+**P2 Product Hunt.** Use only once the interactive site and starter work and there is time to support another launch surface. Prepare the maker assets and account in advance. Do not count it as a source of qualified users until reports support that. The official scheduling and eligibility requirements are in the expansion research.
+
+## Measuring continued use
+
+Save a weekly ledger with date, source channel, voluntary tester identifier, install attempted, own wiki built, first edit, second edit after seven days, recent-month edit and linked report. Record total and qualifying stars separately. Never treat a fork, download or page view as a person writing.
+
+A GitHub visitor may read and leave successfully. Someone reading an issue may find an answer without commenting. Traffic cannot establish bounce rate or intent. GitHub shows visitors, full clones, referrers and popular content for the last 14 days. Save snapshots weekly if comparing launch periods. [Traffic documentation](https://docs.github.com/en/repositories/viewing-activity-and-data-for-your-repository/viewing-traffic-to-a-repository), read 2026-09-08.
+
+On commune.md, proposed anonymous events are starter opened, demo opened, docs opened and GitHub opened, with source tags. An outbound starter click is still not an install. Use voluntary completion receipts to connect acquisition with results. Do not add mandatory accounts or silent tracking inside someone’s wiki to answer a marketing question.
+
+The roadmap’s activation and retention targets are assumptions. At ten reported attempts, inspect where people stopped. At two returning cohorts, inspect whether they edited again. At fifty activations, replace the illustrative funnel rates with observed rates and uncertainty. If there is too little evidence, report too little evidence.
+
+## What would change the recommendation
+
+Astro falls in priority if technically qualified people repeatedly fail the starter or decide they prefer simpler static generators after understanding the difference. The skills angle rises if outside authors repeatedly use the interview and return a week later. The broader Obsidian audience rises only after its editing and publishing round trip works with ordinary notes and the community’s rules permit the discussion.
+
+Grok’s requested X sample should provide original URLs, dates, exact pain statements, current tools and explicit invitations to suggest projects. We will treat each returned post as a lead to verify. Follower counts, repost counts and a model’s audience description alone are insufficient to justify outreach.
+
+[repo]: ../../../README.md
+[changes]: ../../../CHANGELOG.md
+[fixture]: ../../../tests/fixtures/consumer/package.json
+[package]: ../../../package.json
+
+
+## Implementation update on September 8
+
+The proposed starter now exists locally in [examples/starter](../../../examples/starter/README.md), read 2026-09-08. It uses published Commune 0.5.2 with Astro 7.2.10 and has three linked public notes, an update, private and draft fixtures, generic navigation, package panes and static search. The copier creates a separate project and refuses existing destinations or paths inside the starter, including paths through symlinks.
+
+The [local verification receipt](../../../examples/starter/VERIFICATION.md), read 2026-09-08, records a published npm install, six built HTML pages, four markdown twins and nine backlinks. Four automated tests passed. An agent checked pane navigation, backlinks, search and narrower-screen navigation in Chrome. This happened on Devon’s machine. It does not satisfy the independent human install gate.
+
+The [README](../../../README.md), [contribution instructions](../../../CONTRIBUTING.md) and [first-run form](../../../.github/ISSUE_TEMPLATE/first-run.yml), read 2026-09-08, now lead readers to the starter and a specific feedback path. Issue 85 already existed and was pinned when checked. No duplicate issue was created. The [launch checklist](../../../docs/launch/README.md), read 2026-09-08, preserves the outstanding proof requirements.
+
+Commune.md is in a three-concept design round. A concept image is not a deployed package consumer or a recording of working software. The twenty-second demonstration and outside-author return edit remain outstanding. No social posts have been sent. [X-LEADS.md](X-LEADS.md), read 2026-09-08, preserves supplied thread links and conditional reply drafts, with browser verification still unavailable.

--- a/examples/commune-site/DESIGN.md
+++ b/examples/commune-site/DESIGN.md
@@ -1,0 +1,19 @@
+# Commune product surface direction exploration
+
+Status is unselected. Nothing here supersedes the root wiki's design. The user requested a replacement visual world for this separate product site and will select from the three comps.
+
+## Routing Atlas
+
+Electric ultramarine ground, warm white lettering, acid yellow route emphasis. Objective grotesk display with humanist reading text. The first viewport contains a monumental left headline and an actual three-note path on the right. Navigation works like a destination index. Selected paths thicken and note panes open along the path. Mobile turns the horizontal journey into a vertical sequence. Avoid a decorative network cloud.
+
+## Publishing Workshop
+
+Deep aubergine ink, pale pink paper, hot vermilion controls. Literary display serif with extremely confident scale paired with precise understated sans. Broadside masthead gives way to an open reading spread and its markdown source. The signature interaction opens a linked note beside its parent. Mobile reads like a single narrow folio. Risk is looking like an editorial portfolio unless the useful demo appears in the first viewport.
+
+## Open Assembly
+
+Acid yellow ground, near black ink, one tightly condensed grotesk across dramatic size steps. Almost all expression is typographic. The opening promises a wiki in files and the next visible block is a real sample note with links and markdown access. The signature interaction changes the hierarchy of linked titles as the reader follows them. Mobile rebreaks the same type block. Risk is overwhelming quiet reading, so Docs uses the same face's normal width at a restrained scale.
+
+## Shared requirements
+
+Five routes are Home, Start, Demo, Writing and Docs. CTA copy is Start your wiki and Explore the demo. All UI must become semantic text and keyboard-operable links. Comps are illustrations of a proposed interface, not screenshots of shipping functionality. Real content and claims survive selection.

--- a/examples/commune-site/PRODUCT.md
+++ b/examples/commune-site/PRODUCT.md
@@ -1,0 +1,53 @@
+# Commune
+
+<!-- impeccable:product-schema 1 -->
+
+## Platform
+
+web
+
+## Stack
+
+Astro 7. Published package @dmthepm/commune 0.5.2 requires Node 22.12 or newer. This folder owns the proposed commune.md product surface. Concept images precede implementation. No publishing is authorized.
+
+## Users
+
+Primary audience hypothesis from the supplied research is Astro builders who have markdown notes and want a personal wiki they can maintain. Secondary audiences are digital gardeners and authors using Claude Code or Codex. Audience rank is a hypothesis rather than conversion evidence.
+
+## Product Purpose
+
+Keep thinking connected in files the author owns. Publish a personal wiki and inspect its connections during writing.
+
+## Positioning
+
+The build and CLI share the link graph and resolver. The CLI reads markdown from disk without a running Astro process. A draft can be checked for connections before it becomes a published page.
+
+## Operating Context
+
+Authors work in markdown, an editor and Git. Readers follow wikilinks, backlinks and panes. Notes have fetchable markdown twins. Deployment produces static files.
+
+## Capabilities and Constraints
+
+MIT licensed. No account. No editor, transcription service, hosted collaboration or sync service. Optional agent skills support saved rough text, connections, editorial questions, review and shipping. Installed author skills end to end proof remains pending. Public notes enter publishing. Research, pages and updates are included regardless of visibility. Do not claim all private content is automatically protected.
+
+## Brand Commitments
+
+Name is Commune. User owns commune.md. User requests three extraordinary and sharply distinct concepts using GPT 6 and Impeccable. The product surface may depart from the incumbent personal wiki. Honest prose and practical launch copy. No fabricated adoption metrics, testimonials or capabilities.
+
+## Evidence on Hand
+
+Root README and package.json. Research in docs/research/2026-09-08-commune-adoption/OUTPUT.md and RESEARCH.md, read 2026-09-08. The package is real. A portable starter and this product site are work in progress. Outside author proof is pending. Concept content must identify sample notes as sample content.
+
+## Product Principles
+
+Files remain useful independently of Commune.
+
+Show a connection before asking for an install.
+
+Separate current capability from unverified adoption.
+
+Make the first useful action easy to inspect.
+
+## Open Decisions
+
+Visual concept awaits user selection. Five proposed routes are Home, Start, Demo, Writing and Docs. Production integration belongs to the parent task after selection.

--- a/examples/commune-site/concepts/COPY.md
+++ b/examples/commune-site/concepts/COPY.md
@@ -1,0 +1,73 @@
+# Launch copy for the selected direction
+
+Product facts read 2026-09-08 in the root README, package.json and supplied adoption research.
+
+## Home
+
+Use the selected concept headline.
+
+A personal wiki from markdown files. Find connections while you write. Publish with Astro.
+
+Start your wiki
+
+Explore the demo
+
+Open source. MIT. No account.
+
+## Mechanism
+
+Find the connection before you publish.
+
+Commune reads your markdown files from disk. Query the graph while you write, then publish with the same link resolver through Astro.
+
+## Demo
+
+Follow a thought.
+
+Open a sample note, follow its link and find the way back. Read the markdown twin to see the source behind the page.
+
+Small notes
+
+A note can hold one unfinished thought. Give it a name, then connect it to Useful links.
+
+Useful links
+
+A link gives a thought somewhere to go. It can connect Small notes to Writing in public.
+
+Writing in public
+
+Publish something you can return to. The next edit can begin with a question you left in Small notes.
+
+These are sample notes. Their connections must be implemented as real links in the eventual demo.
+
+## Start
+
+Build two linked notes.
+
+You will need Node 22.12 or newer and an Astro 7 project. The portable starter is being prepared. Use its verified installation instructions when it is ready.
+
+Do not put a timed completion promise or an unverified scaffolding command on the live site.
+
+## Writing
+
+Keep the rough thought. Review the finished note.
+
+Optional skills for Claude Code and Codex help save rough text, find connection candidates, ask editorial questions and prepare a reviewed change for shipping. They require an existing Commune wiki.
+
+An end to end run using the installed authoring skills remains unverified.
+
+## Docs
+
+Make the wiki yours.
+
+Start with installation, wikilinks, backlinks, markdown twins and graph commands. Read the visibility rules before publishing. Finish with static hosting and troubleshooting.
+
+## Status
+
+As of 2026-09-08, the published package is 0.5.2. The engine and CLI ship today. Independent first install and installed authoring skills proof remain pending.
+
+## Feedback
+
+Tell us where you had to guess.
+
+Share the step, what you expected and what happened. Add your Node and Commune versions so the problem can be reproduced.

--- a/examples/commune-site/concepts/DIRECTIONS.md
+++ b/examples/commune-site/concepts/DIRECTIONS.md
@@ -1,0 +1,41 @@
+# Three worlds for commune.md
+
+This is a direction round, not an approved production design. Product facts are captured in PRODUCT.md. The explicit task supplies product context and asks for comps before engineering. We are using comp first for this round without recording a standing workflow preference.
+
+## Mechanism and scene
+
+The same files and link resolver support writing at a terminal and reading a published wiki. An Astro author has accumulated markdown and wants to make it navigable without surrendering the files.
+
+The category rut is a centered software pitch above a fake terminal. Its predictable opposite is a quiet cream digital garden with scattered serif text. Neither is the candidate by default.
+
+## Grounded candidates
+
+1. The publishing workshop. A literary publisher's specimen sheet with enormous book typography and open spreads containing actual note content.
+2. The architectural pinup. A wall of working revisions whose source and rendered page can be inspected together.
+3. The field guide. A compact naturalist index with linked observations and navigable marginal references.
+4. The hypertext research paper. Oversized linked passages and a citation apparatus made for following thought.
+5. The programmers' typesetting manual. A confident technical specimen showing source and output with exact correspondence.
+6. The routing atlas. A transport identity system with an electric blue ground, explicit paths and actual note titles as destinations.
+7. The personal exhibition catalogue. A generous image and text catalogue where each work is a note and references form an index.
+
+## Roll
+
+Seed d0a85620 assigned candidate 6. The Routing Atlas leads. The Publishing Workshop remains the pick. The user's request bounds this hand to three complete rendered concepts.
+
+## Challenger judgments
+
+Festival Lineup is competitive on audience identification with independent builders. Hierarchy by type alone provides a braver invitation to write in public. Product clarity requires real linked note passages below the opening typography. This is the third full concept named Open Assembly.
+
+Swiss Grid is declined on both axes against the more legible paths of the atlas. Keep disciplined module changes across breakpoints.
+
+Algorave is declined on both axes because musical performance is not Commune's task. Keep immediate visible correspondence between a source change and its reading view, without pretending there is live collaboration.
+
+Drum Machine is declined on both axes because sequencing beats does not map to maintaining a wiki. Keep a persistent indication of the selected destination.
+
+Sneaker Archive is declined on both axes because boxed collectible inventory misstates open hypertext. Keep compact metadata that remains readable when the composition becomes dense.
+
+Provenance Ribbon is declined on both axes because custody is not the graph's meaning. Keep the distinction between demonstrated capability and pending proof attached to its claim.
+
+## Scope
+
+Generate one equal-fidelity desktop comp for each of the three directions. All show real product language and sample content. Do not implement the production site before selection. The decision page offers a quiet standard category exit and re-roll. No numerical adoption claims. No testimonials. No decorative fake terminal.

--- a/examples/commune-site/concepts/HANDOFF.md
+++ b/examples/commune-site/concepts/HANDOFF.md
@@ -1,0 +1,57 @@
+# Concept round handoff
+
+Three desktop direction comps are complete. No concept has been approved. No production UI, Astro route or functional demo was implemented. No existing src site was modified. No commit, stash, checkout or external publishing was performed. No X access was attempted.
+
+## Review
+
+Comparison board is http://127.0.0.1:65067/
+
+Local node server PID is 96146. It listens only on 127.0.0.1 port 65067. Question key is 4942876d. The Chrome preview tab was marked as a deliverable. No answer wait is running.
+
+The board offers Routing Atlas, Publishing Workshop and Open Assembly. It also carries quiet declined alternatives and a standard category exit. To resume choice collection, use the Impeccable serve-question script with --wait --key 4942876d from this folder. Do not start another server unless this process is gone.
+
+## Verification
+
+All three generated images were visually inspected in the tool render. Each is 1536 by 1024. Browser DOM inspection confirmed the three local preview images loaded, plus the two Open Assembly inspiration images. Screenshot inspection confirmed a readable comparison board. At the observed 700 pixel viewport, document width was also 700 with no horizontal page overflow. The empty lightbox image has no source until opened and is not a failed preview.
+
+No application tests, production build or detector ran because this round authored product and design documents, decision data and raster comps only. No UI implementation was authored. Mobile production behavior is specified but untested.
+
+## Translation cautions
+
+The images are generated proposals, not proof of shipped behavior. Text remains subject to the copy artifact and product facts. Atlas contains faint extra destination labels and loose illustrative prose that should not enter the demo without matching note content. Workshop visually retains wikilink brackets in its reading pane. The production reading view must render the resolved link without brackets. Its book contour is a concept treatment rather than an instruction to rasterize text. Assembly needs the dramatic display face to be properly sourced before implementation.
+
+Exact prompts are in each JSON sidecar and embedded in each PNG. All sidecars record approved false. Use built-in image generation outputs as north stars only after selection.
+
+## Files authored
+
+All paths below are relative to examples/commune-site.
+
+- PRODUCT.md
+- DESIGN.md
+- concepts/DIRECTIONS.md
+- concepts/decision.json
+- concepts/COPY.md
+- concepts/HANDOFF.md
+- .impeccable/mocks/decision/atlas.png
+- .impeccable/mocks/decision/atlas.json
+- .impeccable/mocks/decision/workshop.png
+- .impeccable/mocks/decision/workshop.json
+- .impeccable/mocks/decision/assembly.png
+- .impeccable/mocks/decision/assembly.json
+
+The decision server also created these runtime files.
+
+- .impeccable/questions/4942876d.log
+- .impeccable/questions/4942876d.state.json
+
+Native tool originals remain in the default generated_images folder outside the repository. No other repository files were authored by this concept task.
+
+## Original generated images
+
+All three were made with the built-in image_gen tool. Originals were copied into this folder and left in place.
+
+- Routing Atlas at /Users/devonmeadows/.codex/generated_images/01a081f2-39c5-7ec0-835b-08e8f8113549/exec-6e98b931-7813-471b-9b35-35a8a012fa14.png
+- Publishing Workshop at /Users/devonmeadows/.codex/generated_images/01a081f2-39c5-7ec0-835b-08e8f8113549/exec-fcd5da33-9148-4944-add9-e48c03467897.png
+- Open Assembly at /Users/devonmeadows/.codex/generated_images/01a081f2-39c5-7ec0-835b-08e8f8113549/exec-13de52db-aa37-4f1f-9bb7-21469ffd5ac7.png
+
+Final artifact validation passed. All three PNG headers report 1536 by 1024, all prompt sidecars parse with approved false, decision JSON parses, and the provenance scan reports 3 rasters with 0 missing prompts. No further work or waiting is running in the concept task. The local preview server remains available for the parent and Devon.

--- a/examples/commune-site/concepts/HANDOFF.md
+++ b/examples/commune-site/concepts/HANDOFF.md
@@ -4,11 +4,7 @@ Three desktop direction comps are complete. No concept has been approved. No pro
 
 ## Review
 
-Comparison board is http://127.0.0.1:65067/
-
-Local node server PID is 96146. It listens only on 127.0.0.1 port 65067. Question key is 4942876d. The Chrome preview tab was marked as a deliverable. No answer wait is running.
-
-The board offers Routing Atlas, Publishing Workshop and Open Assembly. It also carries quiet declined alternatives and a standard category exit. To resume choice collection, use the Impeccable serve-question script with --wait --key 4942876d from this folder. Do not start another server unless this process is gone.
+Three directions were compared on a local board during the round: Routing Atlas, Publishing Workshop and Open Assembly, with declined alternatives noted in DIRECTIONS.md. The rendered comps are kept outside the repository; ask the maintainer for them. No direction has been chosen.
 
 ## Verification
 
@@ -32,17 +28,9 @@ All paths below are relative to examples/commune-site.
 - concepts/decision.json
 - concepts/COPY.md
 - concepts/HANDOFF.md
-- .impeccable/mocks/decision/atlas.png
-- .impeccable/mocks/decision/atlas.json
-- .impeccable/mocks/decision/workshop.png
-- .impeccable/mocks/decision/workshop.json
-- .impeccable/mocks/decision/assembly.png
-- .impeccable/mocks/decision/assembly.json
 
 The decision server also created these runtime files.
 
-- .impeccable/questions/4942876d.log
-- .impeccable/questions/4942876d.state.json
 
 Native tool originals remain in the default generated_images folder outside the repository. No other repository files were authored by this concept task.
 

--- a/examples/commune-site/concepts/decision.json
+++ b/examples/commune-site/concepts/decision.json
@@ -1,0 +1,185 @@
+{
+  "title": "Three futures for commune.md",
+  "question": "Choose a direction to carry into the working site, or steer a fresh hand.",
+  "options": [
+    {
+      "id": "atlas",
+      "label": "Routing Atlas",
+      "kicker": "THE ROLL",
+      "lineage": "Transport identity and route diagrams",
+      "thesis": "Every thought leads somewhere.",
+      "palette": [
+        "#163DEB",
+        "#F3F1E8",
+        "#DFFF00"
+      ],
+      "materials": [
+        "electric blue field",
+        "precise route geometry"
+      ],
+      "viewport": "A monumental headline meets three linked sample notes on a navigable route.",
+      "risk": "Routes must stay useful or the map becomes decoration.",
+      "comp": ".impeccable/mocks/decision/atlas.png",
+      "raised": [
+        {
+          "from": "Swiss Grid",
+          "raise": "One modular rhythm governs route maps and dense documentation."
+        },
+        {
+          "from": "Algorave",
+          "raise": "Source and reading views show the same selected passage."
+        },
+        {
+          "from": "Drum Machine",
+          "raise": "The current note remains unmistakable throughout the journey."
+        },
+        {
+          "from": "Sneaker Archive",
+          "raise": "Compact metadata remains readable at high density."
+        },
+        {
+          "from": "Provenance Ribbon",
+          "raise": "Pending proof stays beside the associated capability."
+        }
+      ]
+    },
+    {
+      "id": "workshop",
+      "label": "Publishing Workshop",
+      "kicker": "IMPECCABLE\u2019S PICK",
+      "lineage": "Independent literary publishing and type specimens",
+      "thesis": "Your notes deserve a life beyond the folder.",
+      "palette": [
+        "#34192D",
+        "#F7DCE3",
+        "#F04425"
+      ],
+      "materials": [
+        "ink and paper",
+        "open reading spreads"
+      ],
+      "viewport": "An enormous literary headline opens into two linked pages and their markdown source.",
+      "risk": "Editorial familiarity is deliberate and needs a working demo to earn its place.",
+      "comp": ".impeccable/mocks/decision/workshop.png"
+    },
+    {
+      "id": "assembly",
+      "label": "Open Assembly",
+      "lineage": "Festival lineup typographic hierarchy",
+      "verdict": "competitive",
+      "thesis": "A personal wiki with a public voice.",
+      "palette": [
+        "#E3F136",
+        "#171914"
+      ],
+      "materials": [
+        "saturated ground",
+        "condensed type"
+      ],
+      "viewport": "A full-width type composition steps down into a sample note and its links.",
+      "risk": "The loud opening must give way to a calm reading measure.",
+      "case": "Strong independent-builder identity with a more demanding transition into product explanation.",
+      "comp": ".impeccable/mocks/decision/assembly.png",
+      "hero": "https://impeccable.style/worlds/cards/posters-covers-sleeves-festival-lineup-poster-hero.webp",
+      "board": "https://impeccable.style/worlds/cards/posters-covers-sleeves-festival-lineup-poster.webp"
+    },
+    {
+      "id": "swiss-grid",
+      "label": "Swiss Grid",
+      "verdict": "declined",
+      "thesis": "A considered alternative to the selected route system.",
+      "palette": [
+        "#ffffff",
+        "#151515",
+        "#ea2929"
+      ],
+      "materials": [
+        "catalog reference"
+      ],
+      "viewport": "Form adapted to linked notes and writing.",
+      "risk": "The metaphor competes with the wiki task.",
+      "case": "The atlas is stronger on audience identification and product clarity.",
+      "kept": "Modular discipline"
+    },
+    {
+      "id": "algorave",
+      "label": "Algorave",
+      "verdict": "declined",
+      "thesis": "A considered alternative to the selected route system.",
+      "palette": [
+        "#080808",
+        "#8ce539"
+      ],
+      "materials": [
+        "catalog reference"
+      ],
+      "viewport": "Form adapted to linked notes and writing.",
+      "risk": "The metaphor competes with the wiki task.",
+      "case": "The atlas is stronger on audience identification and product clarity.",
+      "kept": "Visible correspondence between source and output"
+    },
+    {
+      "id": "drum-machine",
+      "label": "Drum Machine",
+      "verdict": "declined",
+      "thesis": "A considered alternative to the selected route system.",
+      "palette": [
+        "#222222",
+        "#ed5226"
+      ],
+      "materials": [
+        "catalog reference"
+      ],
+      "viewport": "Form adapted to linked notes and writing.",
+      "risk": "The metaphor competes with the wiki task.",
+      "case": "The atlas is stronger on audience identification and product clarity.",
+      "kept": "Persistent selection indication"
+    },
+    {
+      "id": "sneaker-archive",
+      "label": "Sneaker Archive",
+      "verdict": "declined",
+      "thesis": "A considered alternative to the selected route system.",
+      "palette": [
+        "#d1642b",
+        "#161616"
+      ],
+      "materials": [
+        "catalog reference"
+      ],
+      "viewport": "Form adapted to linked notes and writing.",
+      "risk": "The metaphor competes with the wiki task.",
+      "case": "The atlas is stronger on audience identification and product clarity.",
+      "kept": "Compact readable metadata"
+    },
+    {
+      "id": "provenance-ribbon",
+      "label": "Provenance Ribbon",
+      "verdict": "declined",
+      "thesis": "A considered alternative to the selected route system.",
+      "palette": [
+        "#eee1cd",
+        "#c62938"
+      ],
+      "materials": [
+        "catalog reference"
+      ],
+      "viewport": "Form adapted to linked notes and writing.",
+      "risk": "The metaphor competes with the wiki task.",
+      "case": "The atlas is stronger on audience identification and product clarity.",
+      "kept": "Evidence remains attached to claims"
+    }
+  ],
+  "reroll": {
+    "registers": [
+      "safer",
+      "bolder"
+    ]
+  },
+  "steer": true,
+  "canon": true,
+  "buildPath": {
+    "value": "comp",
+    "toggle": true
+  }
+}


### PR DESCRIPTION
Research only. `docs/research/2026-09-08-commune-adoption/` holds the plan (OUTPUT.md), the dated evidence (RESEARCH.md) and the community rules research (EXPANSION-RESEARCH.md). `examples/commune-site/` holds PRODUCT.md, DESIGN.md and three concept directions with proposed copy and a handoff; the rendered concept images are kept outside the repository. No direction is chosen and no site is built. Lead lists and draft replies stay private.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X1XXFXAsDP1ftHkaRbgwwz